### PR TITLE
feat(gpu): choose gpus via a BELLMAN_GPUS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Example
 env::set_var("BELLMAN_VERIFIER", "gpu");
 ```
 
+`BELLMAN_GPUS`
+
+If set, filters the Nvidia devices through their bus-ids. The value is a comma separated list of integers.
+
+```
+Example
+env::set_var("BELLMAN_GPUS", "2,3,4");
+```
+
 #### Supported / Tested Cards
 
 Currently only Nvidia hardware is supported, see [issue](https://github.com/finalitylabs/bellman/issues/3). Depending on the size of the proof being passed to the gpu for work, certain cards will not be able to allocate enough memory to either the FFT or Multiexp kernel. Below are a list of devices that work for small sets. In the future we will add the cuttoff point at which a given card will not be able to allocate enough memory to utilize the GPU.

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -1,6 +1,6 @@
 use crate::gpu::{
     error::{GPUError, GPUResult},
-    locks, sources, structs, GPU_NVIDIA_DEVICES,
+    locks, sources, structs, utils, GPU_NVIDIA_DEVICES,
 };
 use ff::Field;
 use log::info;
@@ -64,7 +64,11 @@ where
             .build()?;
 
         info!("FFT: 1 working device(s) selected.");
-        info!("FFT: Device 0: {}", pq.device().name()?);
+        info!(
+            "FFT: Device 0: Bus Id: {} ({})",
+            utils::get_bus_id(device)?,
+            pq.device().name()?
+        );
 
         Ok(FFTKernel {
             proque: pq,

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -319,8 +319,9 @@ where
         );
         for (i, k) in kernels.iter().enumerate() {
             info!(
-                "Multiexp: Device {}: {} (Chunk-size: {})",
+                "Multiexp: Device {}: Bus Id: {} ({}) (Chunk-size: {})",
                 i,
+                utils::get_bus_id(k.proque.device())?,
                 k.proque.device().name()?,
                 k.n
             );

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -69,7 +69,7 @@ pub fn get_core_count(d: Device) -> GPUResult<usize> {
     }
 }
 
-pub fn get_pci_number(d: Device) -> GPUResult<usize> {
+pub fn get_bus_id(d: Device) -> GPUResult<usize> {
     let result = d.info_raw(0x4008)?;
     Ok((result[0] as usize)
         + ((result[1] as usize) << 8)

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -17,19 +17,24 @@ pub fn get_devices(platform_name: &str) -> GPUResult<Vec<Device>> {
         Ok(p) => p == platform_name,
         Err(_) => false,
     });
+
     let bus_ids = env::var("BELLMAN_GPUS").map(|v| {
         v.split(",")
-            .map(|s| s.parse::<u32>().unwrap())
+            .map(|s| s.parse::<u32>().expect("Invalid Bus-Id number!"))
             .collect::<Vec<u32>>()
     });
+
     match platform {
         Some(p) => {
             let mut devs = Device::list_all(p)?;
             if let Ok(bus_ids) = bus_ids {
-                devs = devs
-                    .into_iter()
-                    .filter(|d| bus_ids.contains(&get_bus_id(*d).unwrap()))
-                    .collect();
+                let mut filtered_devs = Vec::new();
+                for d in devs.iter() {
+                    if bus_ids.contains(&get_bus_id(*d)?) {
+                        filtered_devs.push(*d);
+                    }
+                }
+                devs = filtered_devs;
             }
             Ok(devs)
         }

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -89,7 +89,8 @@ pub fn get_core_count(d: Device) -> GPUResult<usize> {
 }
 
 pub fn get_bus_id(d: Device) -> GPUResult<u32> {
-    let result = d.info_raw(0x4008)?;
+    const CL_DEVICE_PCI_BUS_ID_NV: u32 = 0x4008;
+    let result = d.info_raw(CL_DEVICE_PCI_BUS_ID_NV)?;
     Ok((result[0] as u32)
         + ((result[1] as u32) << 8)
         + ((result[2] as u32) << 16)

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -69,6 +69,14 @@ pub fn get_core_count(d: Device) -> GPUResult<usize> {
     }
 }
 
+pub fn get_pci_number(d: Device) -> GPUResult<usize> {
+    let result = d.info_raw(0x4008)?;
+    Ok((result[0] as usize)
+        + ((result[1] as usize) << 8)
+        + ((result[2] as usize) << 16)
+        + ((result[3] as usize) << 24))
+}
+
 pub fn get_memory(d: Device) -> GPUResult<u64> {
     match d.info(ocl::enums::DeviceInfo::GlobalMemSize)? {
         ocl::enums::DeviceInfoResult::GlobalMemSize(sz) => Ok(sz),


### PR DESCRIPTION
`BELLMAN_GPUS`

If set, filters the Nvidia devices through their bus-ids. The value is a comma separated list of integers.

```
Example
env::set_var("BELLMAN_GPUS", "2,3,4");
```
