### PR TITLE
feat(gpu): switch to inplace_fft when memory is not enough for radix_fft

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -327,7 +327,7 @@ pub fn gpu_fft<E: Engine, T: Group<E>>(
     // For compatibility/performance reasons we decided to transmute the array to the desired type
     // as it seems safe and needs less modifications in the current structure of Bellman library.
     let a = unsafe { std::mem::transmute::<&mut [T], &mut [E::Fr]>(a) };
-    kern.radix_fft(a, omega, log_n)?;
+    kern.fft(a, omega, log_n)?;
     Ok(())
 }
 

--- a/src/gpu/fft/fft.cl
+++ b/src/gpu/fft/fft.cl
@@ -67,6 +67,43 @@ __kernel void radix_fft(__global FIELD* x, // Source buffer
   }
 }
 
+/*
+ * Bitreverse elements before doing inplace FFT
+ */
+__kernel void reverse_bits(__global FIELD* a, // Source buffer
+                           uint lgn) // Log2 of n
+{
+  uint k = get_global_id(0);
+  uint rk = bitreverse(k, lgn);
+  if(k < rk) {
+    FIELD old = a[rk];
+    a[rk] = a[k];
+    a[k] = old;
+  }
+}
+
+/*
+ * Inplace FFT algorithm, uses 1/2 less memory than radix-fft
+ * Inspired from original bellman FFT implementation
+ */
+__kernel void inplace_fft(__global FIELD* a, // Source buffer
+                          __global FIELD* omegas, // [omega, omega^2, omega^4, ...]
+                          uint lgn,
+                          uint lgm) // Log2 of n
+{
+  uint gid = get_global_id(0);
+  uint n = 1 << lgn;
+  uint m = 1 << lgm;
+  uint j = gid & (m - 1);
+  uint k = 2 * m * (gid >> lgm);
+  FIELD w = FIELD_pow_lookup(omegas, j << (lgn - 1 - lgm));
+  FIELD t = FIELD_mul(a[k + j + m], w);
+  FIELD tmp = a[k + j];
+  tmp = FIELD_sub(tmp, t);
+  a[k + j + m] = tmp;
+  a[k + j] = FIELD_add(a[k + j], t);
+}
+
 /// Multiplies all of the elements by `field`
 __kernel void mul_by_field(__global FIELD* elements,
                         uint n,

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -19,7 +19,7 @@ where
         return Err(GPUError::GPUDisabled);
     }
 
-    pub fn radix_fft(&mut self, _: &mut [E::Fr], _: &E::Fr, _: u32) -> GPUResult<()> {
+    pub fn fft(&mut self, _: &mut [E::Fr], _: &E::Fr, _: u32) -> GPUResult<()> {
         return Err(GPUError::GPUDisabled);
     }
 }


### PR DESCRIPTION
Closes #95 
This reduces the minimum GPU memory requirement of the prover from 8GB to 4GB, with some performance penalty. Thus the users will experience less MEM_ALLOCATION_ERRORs. The in-place version is only used when memory is not enough, otherwise, radix_fft (Faster version) will be used.