### PR TITLE
fix: print location of lock file

### DIFF
--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -16,8 +16,10 @@ fn tmp_path(filename: &str) -> PathBuf {
 pub struct GPULock(File);
 impl GPULock {
     pub fn lock() -> GPULock {
-        debug!("Acquiring GPU lock...");
-        let f = File::create(tmp_path(GPU_LOCK_NAME)).unwrap();
+        let gpu_lock_file = tmp_path(GPU_LOCK_NAME);
+        debug!("Acquiring GPU lock at {:?} ...", &gpu_lock_file);
+        let f = File::create(&gpu_lock_file)
+            .unwrap_or_else(|_| panic!("Cannot create GPU lock file at {:?}", &gpu_lock_file));
         f.lock_exclusive().unwrap();
         debug!("GPU lock acquired!");
         GPULock(f)
@@ -37,8 +39,14 @@ impl Drop for GPULock {
 pub struct PriorityLock(File);
 impl PriorityLock {
     pub fn lock() -> PriorityLock {
-        debug!("Acquiring priority lock...");
-        let f = File::create(tmp_path(PRIORITY_LOCK_NAME)).unwrap();
+        let priority_lock_file = tmp_path(PRIORITY_LOCK_NAME);
+        debug!("Acquiring priority lock at {:?} ...", &priority_lock_file);
+        let f = File::create(&priority_lock_file).unwrap_or_else(|_| {
+            panic!(
+                "Cannot create priority lock file at {:?}",
+                &priority_lock_file
+            )
+        });
         f.lock_exclusive().unwrap();
         debug!("Priority lock acquired!");
         PriorityLock(f)


### PR DESCRIPTION
Sometimes it might not clear where lock files are actually written
at. Hence print the lock file location on errors and if debug
logging is enabled.

This was triggered by a user where the locking failed and the error
message wasn't that clear.