### PR TITLE
add batch verification benchmark subcrate

### DIFF
--- a/examples/verifier_bench/Cargo.toml
+++ b/examples/verifier_bench/Cargo.toml
@@ -1,0 +1,44 @@
+
+[package]
+name = "bellpersn-verifier-bench"
+version = "0.0.1"
+edition = "2018"
+
+[dependencies]
+bellman = { path = "../..", package = "bellperson" }
+ff = { version = "0.2.0", package = "fff" }
+bit-vec = "0.6"
+blake2s_simd = "0.5"
+futures = "0.1"
+futures-cpupool = { version = "0.1", optional = true }
+groupy = "0.3.1"
+num_cpus = { version = "1", optional = true }
+crossbeam = { version = "0.7", optional = true }
+paired = { version = "0.20.0", optional = true }
+rand_core = "0.5"
+byteorder = "1"
+log = "0.4.8"
+lazy_static = "1.4.0"
+ocl = { version = "0.19.4", package = "fil-ocl", optional = true }
+itertools = { version = "0.9.0", optional = true }
+fs2 = { version = "0.4.3", optional = true }
+rand = "0.7"
+rayon = "1.3.0"
+memmap = "0.7.0"
+thiserror = "1.0.10"
+ahash = "0.3.4"
+structopt = { version = "0.3", default-features = false }
+env_logger = "0.7.1"
+
+
+[features]
+default = ["groth16", "multicore"]
+gpu = ["ocl", "itertools", "fs2"]
+groth16 = ["paired"]
+multicore = ["futures-cpupool", "crossbeam", "num_cpus"]
+
+[[test]]
+name = "mimc"
+path = "tests/mimc.rs"
+required-features = ["groth16"]
+

--- a/examples/verifier_bench/src/bin/main.rs
+++ b/examples/verifier_bench/src/bin/main.rs
@@ -1,0 +1,228 @@
+// --prove                  Benchmark prover
+// --verify                 Benchmark verifier
+// --proofs <num>           Sets number of proofs in a batch
+// --public <num>           Sets number of public inputs
+// --private <num>          Sets number of private inputs
+// --gpu                    Enables GPU
+// --samples                Number of runs
+// --dummy                  Skip param generation and generate dummy params/proofs
+
+use ff::{Field, PrimeField};
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
+
+use bellman::groth16::{
+    create_random_proof_batch, generate_random_parameters, prepare_batch_verifying_key,
+    verify_proofs_batch, Parameters, Proof, VerifyingKey,
+};
+use bellman::{Circuit, ConstraintSystem, SynthesisError};
+use groupy::CurveProjective;
+use paired::bls12_381::{Bls12, Fr};
+use paired::Engine;
+use std::time::Instant;
+use structopt::StructOpt;
+
+macro_rules! timer {
+    ($e:expr) => {{
+        let before = Instant::now();
+        let ret = $e;
+        (
+            ret,
+            (before.elapsed().as_secs() * 1000 as u64 + before.elapsed().subsec_millis() as u64),
+        )
+    }};
+}
+
+#[derive(Clone)]
+pub struct DummyDemo {
+    pub public: usize,
+    pub private: usize,
+}
+
+impl<E: Engine> Circuit<E> for DummyDemo {
+    fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+        assert!(self.public >= 1);
+        let mut x_val = E::Fr::from_str("2");
+        let mut x = cs.alloc_input(|| "", || x_val.ok_or(SynthesisError::AssignmentMissing))?;
+        let mut pubs = 1;
+
+        for _ in 0..self.private + self.public - 1 {
+            // Allocate: x * x = x2
+            let x2_val = x_val.map(|mut e| {
+                e.square();
+                e
+            });
+
+            let x2 = if pubs < self.public {
+                pubs += 1;
+                cs.alloc_input(|| "", || x2_val.ok_or(SynthesisError::AssignmentMissing))?
+            } else {
+                cs.alloc(|| "", || x2_val.ok_or(SynthesisError::AssignmentMissing))?
+            };
+
+            // Enforce: x * x = x2
+            cs.enforce(|| "", |lc| lc + x, |lc| lc + x, |lc| lc + x2);
+
+            x = x2;
+            x_val = x2_val;
+        }
+
+        cs.enforce(
+            || "",
+            |lc| lc + (x_val.unwrap(), CS::one()),
+            |lc| lc + CS::one(),
+            |lc| lc + x,
+        );
+
+        Ok(())
+    }
+}
+
+fn random_points<C: CurveProjective, R: Rng>(count: usize, rng: &mut R) -> Vec<C::Affine> {
+    // Number of distinct points is limited because generating random points is very time
+    // consuming, so it's better to just repeat them.
+    const DISTINT_POINTS: usize = 100;
+    (0..DISTINT_POINTS)
+        .map(|_| C::random(rng).into_affine())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .cycle()
+        .take(count)
+        .collect()
+}
+
+fn dummy_proofs<E: Engine, R: Rng>(count: usize, rng: &mut R) -> Vec<Proof<E>> {
+    (0..count)
+        .map(|_| Proof {
+            a: E::G1::random(rng).into_affine(),
+            b: E::G2::random(rng).into_affine(),
+            c: E::G1::random(rng).into_affine(),
+        })
+        .collect()
+}
+
+fn dummy_inputs<E: Engine, R: Rng>(count: usize, rng: &mut R) -> Vec<<E as ff::ScalarEngine>::Fr> {
+    (0..count)
+        .map(|_| <E as ff::ScalarEngine>::Fr::random(rng))
+        .collect()
+}
+
+fn dummy_vk<E: Engine, R: Rng>(public: usize, rng: &mut R) -> VerifyingKey<E> {
+    VerifyingKey {
+        alpha_g1: E::G1::random(rng).into_affine(),
+        beta_g1: E::G1::random(rng).into_affine(),
+        beta_g2: E::G2::random(rng).into_affine(),
+        gamma_g2: E::G2::random(rng).into_affine(),
+        delta_g1: E::G1::random(rng).into_affine(),
+        delta_g2: E::G2::random(rng).into_affine(),
+        ic: random_points::<E::G1, _>(public + 1, rng),
+    }
+}
+
+fn dummy_params<E: Engine, R: Rng>(public: usize, private: usize, rng: &mut R) -> Parameters<E> {
+    let count = public + private;
+    let hlen = (1 << (((count + public + 1) as f64).log2().ceil() as usize)) - 1;
+    Parameters {
+        vk: dummy_vk(public, rng),
+        h: Arc::new(random_points::<E::G1, _>(hlen, rng)),
+        l: Arc::new(random_points::<E::G1, _>(private, rng)),
+        a: Arc::new(random_points::<E::G1, _>(count, rng)),
+        b_g1: Arc::new(random_points::<E::G1, _>(count, rng)),
+        b_g2: Arc::new(random_points::<E::G2, _>(count, rng)),
+    }
+}
+
+#[derive(Debug, StructOpt, Clone, Copy)]
+#[structopt(name = "Bellman Bench", about = "Benchmarking Bellman.")]
+struct Opts {
+    #[structopt(long = "proofs", default_value = "1")]
+    proofs: usize,
+    #[structopt(long = "public", default_value = "1")]
+    public: usize,
+    #[structopt(long = "private", default_value = "1000000")]
+    private: usize,
+    #[structopt(long = "samples", default_value = "10")]
+    samples: usize,
+    #[structopt(long = "gpu")]
+    gpu: bool,
+    #[structopt(long = "verify")]
+    verify: bool,
+    #[structopt(long = "prove")]
+    prove: bool,
+    #[structopt(long = "dummy")]
+    dummy: bool,
+}
+
+fn main() {
+    let rng = &mut thread_rng();
+    env_logger::init();
+
+    let opts = Opts::from_args();
+    if opts.gpu {
+        std::env::set_var("BELLMAN_VERIFIER", "gpu");
+    } else {
+        std::env::set_var("BELLMAN_NO_GPU", "1");
+    }
+
+    let circuit = DummyDemo {
+        public: opts.public,
+        private: opts.private,
+    };
+    let circuits = vec![circuit.clone(); opts.proofs];
+
+    let params = if opts.dummy {
+        dummy_params::<Bls12, _>(opts.public, opts.private, rng)
+    } else {
+        println!("Generating params... (You can skip this by passing `--dummy` flag)");
+        generate_random_parameters(circuit.clone(), rng).unwrap()
+    };
+    let pvk = prepare_batch_verifying_key(&params.vk);
+
+    if opts.prove {
+        println!("Proving...");
+
+        for _ in 0..opts.samples {
+            let (_, took) =
+                timer!(create_random_proof_batch(circuits.clone(), &params, rng).unwrap());
+            println!("Proof generation finished in {}ms", took);
+        }
+    }
+
+    if opts.verify {
+        println!("Verifying...");
+
+        let (inputs, proofs) = if opts.dummy {
+            (
+                dummy_inputs::<Bls12, _>(opts.public, rng),
+                dummy_proofs::<Bls12, _>(opts.proofs, rng),
+            )
+        } else {
+            let mut inputs = Vec::new();
+            let mut num = Fr::one();
+            num.double();
+            for _ in 0..opts.public {
+                inputs.push(num);
+                num.square();
+            }
+            println!("(Generating valid proofs...)");
+            let proofs = create_random_proof_batch(circuits.clone(), &params, rng).unwrap();
+            (inputs, proofs)
+        };
+
+        for _ in 0..opts.samples {
+            let pref = proofs.iter().collect::<Vec<&_>>();
+            println!(
+                "{} proofs, each having {} public inputs...",
+                opts.proofs, opts.public
+            );
+            let (valid, took) = timer!(verify_proofs_batch(
+                &pvk,
+                rng,
+                &pref[..],
+                &vec![inputs.clone(); opts.proofs]
+            )
+            .unwrap());
+            println!("Verification finished in {}ms (Valid: {})", took, valid);
+        }
+    }
+}


### PR DESCRIPTION
This replaces #74 without yet changing its functionality.

Changes:
- Moved to a subcrate in order to avoid adding dependencies to the main crate.
- Rebased on `master`.

Example usage:

```
cargo run -- --dummy --proofs=10 -public=100 --verify
```

Recommended next steps:
- Accept a list of values for number of public inputs (`--public`) and number of proofs (`--proofs`) then run every combination (the cartesian product) of those inputs.
- Add a flag to allow averaging the samples.

With these changes, it should be possible to run a single command to produce the table whose values interest us. Without these or similar changes, doing so will be very time-consuming and error-prone. Once generating the desired results is easy, we can merge this to all branches which need to be checked.
