### PR TITLE
Add proof-benchmarking output.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rayon = "1.3.0"
 memmap = "0.7.0"
 thiserror = "1.0.10"
 ahash = "0.3.4"
-rust-gpu-tools = { version = "0.1.0", optional = true }
+rust-gpu-tools = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -111,7 +111,7 @@ where
                 pq[i].mul_assign(&twiddle);
             }
         }
-        self.pq_buffer.write_from(&pq)?;
+        self.pq_buffer.write_from(0, &pq)?;
 
         // Precalculate [omega, omega^2, omega^4, omega^8, ..., omega^(2^31)]
         let mut omegas = vec![E::Fr::zero(); 32];
@@ -119,7 +119,7 @@ where
         for i in 1..LOG2_MAX_ELEMENTS {
             omegas[i] = omegas[i - 1].pow([2u64]);
         }
-        self.omegas_buffer.write_from(&omegas)?;
+        self.omegas_buffer.write_from(0, &omegas)?;
 
         Ok(())
     }
@@ -135,7 +135,7 @@ where
         let max_deg = cmp::min(MAX_LOG2_RADIX, log_n);
         self.setup_pq_omegas(omega, n, max_deg)?;
 
-        src_buffer.write_from(&*a)?;
+        src_buffer.write_from(0, &*a)?;
         let mut log_p = 0u32;
         while log_p < log_n {
             let deg = cmp::min(max_deg, log_n - log_p);
@@ -144,7 +144,7 @@ where
             std::mem::swap(&mut src_buffer, &mut dst_buffer);
         }
 
-        src_buffer.read_into(a)?;
+        src_buffer.read_into(0, a)?;
 
         Ok(())
     }

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -140,11 +140,11 @@ where
         // Each thread will use `num_groups` * `num_windows` * `bucket_len` buckets.
 
         let mut base_buffer = self.program.create_buffer::<G>(n)?;
-        base_buffer.write_from(bases)?;
+        base_buffer.write_from(0, bases)?;
         let mut exp_buffer = self
             .program
             .create_buffer::<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>(n)?;
-        exp_buffer.write_from(exps)?;
+        exp_buffer.write_from(0, exps)?;
 
         let bucket_buffer = self
             .program
@@ -183,7 +183,7 @@ where
         )?;
 
         let mut results = vec![<G as CurveAffine>::Projective::zero(); num_groups * num_windows];
-        result_buffer.read_into(&mut results)?;
+        result_buffer.read_into(0, &mut results)?;
 
         // Using the algorithm below, we can calculate the final result by accumulating the results
         // of those `NUM_GROUPS` * `NUM_WINDOWS` threads.

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -8,6 +8,8 @@ lazy_static::lazy_static! {
         let mut core_counts : HashMap<String, usize> = vec![
             // AMD
             ("gfx1010".to_string(), 2560),
+            // This value was chosen to give (approximately) empirically best performance for a Radeon Pro VII.
+            ("gfx906".to_string(), 7400),
 
             // NVIDIA
             ("Quadro RTX 6000".to_string(), 4608),

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use ff::{Field, PrimeField};
 use futures::Future;
@@ -304,6 +305,10 @@ where
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    // Start fft/multiexp prover timer
+    let start = Instant::now();
+    info!("starting proof timer");
+
     let worker = Worker::new();
     let input_len = provers[0].input_assignment.len();
     let vk = params.get_vk(input_len)?;
@@ -561,6 +566,9 @@ where
             },
         )
         .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+    let proof_time = start.elapsed();
+    info!("prover time: {:?}", proof_time);
 
     Ok(proofs)
 }


### PR DESCRIPTION
This PR adds truly minimal benchmarking output to simplify measurement and optimization of proving.

It also upgrades to `rust-gpu-tool` v0.2.0, which seems to fix some slow downstream CI issues — although it's unclear why.

Here is the CI run which consumes this branch: https://app.circleci.com/pipelines/github/filecoin-project/rust-fil-proofs/2614/workflows/1b7eaf56-12ab-45b9-b0f7-7403af57821c

For comparison, here is the slow CI run which differs only by this commit: https://app.circleci.com/pipelines/github/filecoin-project/rust-fil-proofs/2482/workflows/85ccd4f7-1f7f-4054-bf1b-27a6aeb311fa

Overview (for easiest comparison) here:  https://app.circleci.com/pipelines/github/filecoin-project/rust-fil-proofs?branch=bellperson-tests
