### PR TITLE
perf: use better FxHash instead of aHash to speed up circuit computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.7"
 rayon = "1.3.0"
 memmap = "0.7.0"
 thiserror = "1.0.10"
-ahash = "0.5.6"
+rustc-hash = "1.1.0"
 num_cpus = "1"
 crossbeam-channel = "0.5.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub mod multiexp;
 pub mod util_cs;
 use ff::{Field, ScalarEngine};
 
-use ahash::AHashMap as HashMap;
+use rustc_hash::FxHashMap as HashMap;
 use std::io;
 use std::marker::PhantomData;
 use std::ops::{Add, Sub};
@@ -205,7 +205,7 @@ impl<E: ScalarEngine> Default for LinearCombination<E> {
 
 impl<E: ScalarEngine> LinearCombination<E> {
     pub fn zero() -> LinearCombination<E> {
-        LinearCombination(HashMap::new())
+        LinearCombination(HashMap::default())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&Variable, &E::Fr)> + '_ {


### PR DESCRIPTION
The previously used HashMap by aHash can be greatly improved by using std HashMap and FxHash, Using [rustc-hash](https://github.com/rust-lang/rustc-hash) will be 4x faster than ahash in circuit synthesis.