### PR TITLE
Create code coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
       - run:
           name: Generate coverage report
           command: |
-            RUST_LOG=info cargo +<< pipeline.parameters.nightly-version >> test << parameters.cargo-args >> -- --nocapture << parameters.test-args >>
+            RUST_LOG=info cargo +<< pipeline.parameters.nightly-version >> test --features _coverage << parameters.cargo-args >> -- --nocapture << parameters.test-args >>
 
             # Do *not* use sparse output. It leads to more lines that are not
             # taken into account at all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+parameters:
+  nightly-version:
+    type: string
+    default: "nightly-2020-11-20"
+
+orbs:
+  codecov: codecov/codecov@1
+
 executors:
   default:
     machine:
@@ -14,7 +22,7 @@ restore-workspace: &restore-workspace
 restore-cache: &restore-cache
   restore_cache:
     keys:
-      - cargo-v0-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - cargo-v1-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - repo-source-{{ .Branch }}-{{ .Revision }}
 
 commands:
@@ -24,7 +32,7 @@ commands:
           name: Set the PATH env variable
           command: |
             # Also put the Rust LLVM tools into the PATH.
-            echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' | tee --append $BASH_ENV
+            echo 'export PATH="$HOME:~/.cargo/bin:~/.rustup/toolchains/<< pipeline.parameters.nightly-version >>-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:$PATH"' | tee --append $BASH_ENV
             source $BASH_ENV
 
   install-gpu-deps:
@@ -34,7 +42,6 @@ commands:
           command: |
             sudo apt-get update -y
             sudo apt install -y ocl-icd-opencl-dev
-
 
   test_target_pairing:
     parameters:
@@ -103,13 +110,16 @@ jobs:
           command: cargo generate-lockfile
       - restore_cache:
           keys:
-            - cargo-v0-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v1-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run: cargo update
       - run: cargo fetch
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
+      # A nightly build is needed for code coverage reporting
+      - run: rustup toolchain install --profile minimal << pipeline.parameters.nightly-version >>
       - run: rustup component add rustfmt-preview
       - run: rustup component add clippy-preview
+      - run: rustup component add --toolchain << pipeline.parameters.nightly-version >> llvm-tools-preview
       - run: rustc --version
       - run: rm -rf .git
       - persist_to_workspace:
@@ -117,7 +127,7 @@ jobs:
           paths:
             - gpuci
       - save_cache:
-          key: cargo-v0-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v1-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
           paths:
             - "~/.cargo"
             - "~/.rustup"
@@ -201,6 +211,55 @@ jobs:
           name: Run cargo release build
           command: cargo build --release --no-default-features --features pairing
 
+  coverage_run:
+    executor: default
+    parameters:
+      cargo-args:
+        description: Addtional arguments for the cargo command
+        type: string
+        default: ""
+      test-args:
+        description: Additional arguments for the test executable (after the `--`)
+        type: string
+        default: ""
+    environment:
+      # Incremental build is not supported when profiling
+      CARGO_INCREMENTAL: 0
+      # -Zinstrument-coverage: enable llvm coverage instrumentation
+      # -Ccodegen-units=1: building in parallel is not supported when profiling
+      # -Copt-level=0: disable optimizations for more accurate coverage
+      # -Clink-dead-code: dead code should be considered as not covered code
+      # -Coverflow-checks=off: checking for overflow is not needed for coverage reporting
+      # -Cinline-threshold=0: do not inline
+      RUSTFLAGS: -Zinstrument-coverage -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cinline-threshold=0
+      # Make sure that each run of an executable creates a new profile file, with the default
+      # name they would override each other
+      LLVM_PROFILE_FILE: "%m.profraw"
+    steps:
+      - *restore-workspace
+      - *restore-cache
+      - set-env-path
+      - install-gpu-deps
+      - run:
+          name: Generate coverage report
+          command: |
+            RUST_LOG=info cargo +<< pipeline.parameters.nightly-version >> test << parameters.cargo-args >> -- --nocapture << parameters.test-args >>
+
+            # Do *not* use sparse output. It leads to more lines that are not
+            # taken into account at all
+            llvm-profdata merge --output=default.profdata ./*.profraw
+
+            # The compiled files contain the coverage information. From running the tests we don't
+            # know what those files are called, hence use all files from the `./target/debug/deps`
+            # directory which don't have an extension.
+            OBJECT_FILES=$(find ./target/debug/deps/* -name '*' -not -name '*\.*' -printf '%p,'|head --bytes -1)
+            # Only export the coverage of this project, we don't care about coverage of
+            # dependencies
+            llvm-cov export --ignore-filename-regex=".cargo|.rustup" --format=lcov -instr-profile=default.profdata --object=${OBJECT_FILES} > lcov.info
+      # Codecov automatically merges the reports in case there are several ones uploaded
+      - codecov/upload:
+          file: lcov.info
+
 workflows:
   version: 2.1
 
@@ -234,4 +293,22 @@ workflows:
       - build_pairing:
           requires:
             - cargo_fetch
-            
+
+      - coverage_run:
+          name: coverage_default_features
+          requires:
+            - cargo_fetch
+      - coverage_run:
+          name: coverage_gpu_feature_lib
+          cargo-args: "--features gpu --lib"
+          # If run in parallel the GPU tests will block and hence fail
+          test-args: "--test-threads=1"
+          requires:
+            - cargo_fetch
+      - coverage_run:
+          name: coverage_gpu_feature_integration
+          cargo-args: "--features gpu --test '*'"
+          # If run in parallel the GPU tests will block and hence fail
+          test-args: "--test-threads=1"
+          requires:
+            - cargo_fetch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,10 @@ blst-serde = ["blstrs/serde"]
 pairing = ["paired", "groth16"]
 pairing-serde = ["paired/serde"]
 
+# This feature disables/modifies long running tests to make the suitable for code coverage
+# reporting
+_coverage = []
+
 [[test]]
 name = "mimc"
 path = "tests/mimc.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! - Compute `hash = SHA-256d(preimage)` inside the circuit.
 //! - Expose `hash` as a public input using multiscalar packing.
 //!
-//! ```
+//! ```no_run
 //! use bellperson::{
 //!     gadgets::{
 //!         boolean::{AllocatedBit, Boolean},

--- a/tests/gpu_provers.rs
+++ b/tests/gpu_provers.rs
@@ -57,11 +57,17 @@ pub fn test_parallel_prover() {
 
     // Higher prio circuit
     let c = DummyDemo {
+        #[cfg(not(feature = "_coverage"))]
         interations: 10_000,
+        #[cfg(feature = "_coverage")]
+        interations: 100,
     };
     // Lower prio circuit
     let c2 = DummyDemo {
+        #[cfg(not(feature = "_coverage"))]
         interations: 500_000,
+        #[cfg(feature = "_coverage")]
+        interations: 5000,
     };
 
     let params = generate_random_parameters::<Bls12, _, _>(c.clone(), rng).unwrap();


### PR DESCRIPTION
The doc test runs a long time when coupled with code coverage instrumentation,
hence disable it.

First #137 and #138 should be merged, then this one should be rebased.

The tests are flaky, it seems unrelated to the code-coverage changes. I suspect that sometimes they deadlock for some reason. This should surely be investigated if it's a re-ocuring thing, but it's out of scope for this PR and I don't think this PR should be blocked by those problems.