### PR TITLE
fix(gpu): only create PriorityLock when the GPU exists

### DIFF
--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 
 const GPU_LOCK_NAME: &str = "bellman.gpu.lock";
 const PRIORITY_LOCK_NAME: &str = "bellman.priority.lock";
+pub const BELLMAN_NO_GPU: &str = "BELLMAN_NO_GPU";
+
 fn tmp_path(filename: &str) -> PathBuf {
     let mut p = std::env::temp_dir();
     p.push(filename);
@@ -116,7 +118,7 @@ macro_rules! locked_kernel {
             where
                 F: FnMut(&mut $kern<E>) -> GPUResult<R>,
             {
-                if std::env::var("BELLMAN_NO_GPU").is_ok() {
+                if std::env::var(BELLMAN_NO_GPU).is_ok() {
                     return Err(GPUError::GPUDisabled);
                 }
 

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -80,6 +80,18 @@ pub fn dump_device_list() {
 }
 
 #[cfg(feature = "gpu")]
+pub fn has_gpu() -> bool {
+    use super::locks::BELLMAN_NO_GPU;
+    if std::env::var(BELLMAN_NO_GPU).is_ok() {
+        return false;
+    }
+
+    opencl::Device::all()
+        .map(|d| !d.is_empty())
+        .unwrap_or(false)
+}
+
+#[cfg(feature = "gpu")]
 #[test]
 pub fn test_list_devices() {
     let _ = env_logger::try_init();

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -18,7 +18,7 @@ use crate::{
 use log::info;
 
 #[cfg(feature = "gpu")]
-use crate::gpu::PriorityLock;
+use crate::gpu::{has_gpu, PriorityLock};
 
 fn eval<E: Engine>(
     lc: &LinearCombination<E>,
@@ -328,7 +328,7 @@ where
     }
 
     #[cfg(feature = "gpu")]
-    let prio_lock = if priority {
+    let prio_lock = if priority && has_gpu() {
         Some(PriorityLock::lock())
     } else {
         None


### PR DESCRIPTION
When we are not using GPU, creating a GPU lock is a weird behavior for us. (The "gpu" feature was enabled in rust-filecoin-proofs-api by default)