### PR TITLE
perf: improve proving performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ paired = { version = "0.22.0", optional = true }
 rust-gpu-tools = { version = "0.3.0", optional = true }
 ff-cl-gen = { version = "0.3.0", optional = true }
 fs2 = { version = "0.4.3", optional = true }
+yastl = "0.1.2"
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -12,10 +12,10 @@
 //! [Groth16]: https://eprint.iacr.org/2016/260
 
 use crate::bls::Engine;
+use crate::multicore::Worker;
 use ff::{Field, PrimeField, ScalarEngine};
 use groupy::CurveProjective;
 
-use super::multicore::Worker;
 use super::SynthesisError;
 
 use crate::gpu;

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -104,7 +104,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
             let minv = self.minv;
 
             for v in self.coeffs.chunks_mut(chunk) {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     for v in v {
                         v.group_mul_assign(&minv);
                     }
@@ -118,7 +118,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
     pub fn distribute_powers(&mut self, worker: &Worker, g: E::Fr) {
         worker.scope(self.coeffs.len(), |scope, chunk| {
             for (i, v) in self.coeffs.chunks_mut(chunk).enumerate() {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     let mut u = g.pow(&[(i * chunk) as u64]);
                     for v in v.iter_mut() {
                         v.group_mul_assign(&u);
@@ -170,7 +170,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
             for v in self.coeffs.chunks_mut(chunk) {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     for v in v {
                         v.group_mul_assign(&i);
                     }
@@ -189,7 +189,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
                 .chunks_mut(chunk)
                 .zip(other.coeffs.chunks(chunk))
             {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     for (a, b) in a.iter_mut().zip(b.iter()) {
                         a.group_mul_assign(&b.0);
                     }
@@ -208,7 +208,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
                 .chunks_mut(chunk)
                 .zip(other.coeffs.chunks(chunk))
             {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     for (a, b) in a.iter_mut().zip(b.iter()) {
                         a.group_sub_assign(&b);
                     }
@@ -392,7 +392,7 @@ fn parallel_fft<E: ScalarEngine, T: Group<E>>(
         let a = &*a;
 
         for (j, tmp) in tmp.iter_mut().enumerate() {
-            scope.spawn(move |_scope| {
+            scope.execute(move || {
                 // Shuffle into a sub-FFT
                 let omega_j = omega.pow(&[j as u64]);
                 let omega_step = omega.pow(&[(j as u64) << log_new_n]);
@@ -420,7 +420,7 @@ fn parallel_fft<E: ScalarEngine, T: Group<E>>(
         let tmp = &tmp;
 
         for (idx, a) in a.chunks_mut(chunk).enumerate() {
-            scope.spawn(move |_scope| {
+            scope.execute(move || {
                 let mut idx = idx * chunk;
                 let mask = (1 << log_cpus) - 1;
                 for a in a {

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -288,7 +288,7 @@ where
 
         let mut acc = <G as CurveAffine>::Projective::zero();
 
-        let results = crate::multicore::THREAD_POOL.install(|| {
+        let results = crate::multicore::RAYON_THREAD_POOL.install(|| {
             if n > 0 {
                 bases
                 .par_chunks(chunk_size)

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -308,11 +308,11 @@ where
 
                             Ok(acc)
                         })
-                        .try_fold(|| <G as CurveAffine>::Projective::zero(), |mut acc, part| -> Result<_, GPUError> {
+                        .try_fold(<G as CurveAffine>::Projective::zero, |mut acc, part| -> Result<_, GPUError> {
                             acc.add_assign(&part?);
                             Ok(acc)
                         })
-                        .try_reduce(|| <G as CurveAffine>::Projective::zero(), |mut acc, part| -> Result<_, GPUError> {
+                        .try_reduce(<G as CurveAffine>::Projective::zero, |mut acc, part| -> Result<_, GPUError> {
                             acc.add_assign(&part);
                             Ok(acc)
                         })

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -80,3 +80,6 @@ macro_rules! locked_kernel {
 
 locked_kernel!(LockedFFTKernel);
 locked_kernel!(LockedMultiexpKernel);
+
+#[derive(Debug)]
+pub struct PriorityLock;

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -1,5 +1,4 @@
 use super::error::{GPUError, GPUResult};
-use crate::multicore::Worker;
 use ff::{PrimeField, ScalarEngine};
 use groupy::CurveAffine;
 use std::marker::PhantomData;
@@ -38,7 +37,6 @@ where
 
     pub fn multiexp<G>(
         &mut self,
-        _: &Worker,
         _: Arc<Vec<G>>,
         _: Arc<Vec<<<G::Engine as ScalarEngine>::Fr as PrimeField>::Repr>>,
         _: usize,

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -73,6 +73,8 @@ macro_rules! locked_kernel {
                 return Err(GPUError::GPUDisabled);
             }
         }
+
+        unsafe impl<E: Engine> Send for $class<E> {}
     };
 }
 

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -242,7 +242,7 @@ where
             let powers_of_tau = powers_of_tau.as_mut();
             worker.scope(powers_of_tau.len(), |scope, chunk| {
                 for (i, powers_of_tau) in powers_of_tau.chunks_mut(chunk).enumerate() {
-                    scope.spawn(move |_scope| {
+                    scope.execute(move || {
                         let mut current_tau_power = tau.pow(&[(i * chunk) as u64]);
 
                         for p in powers_of_tau {
@@ -266,7 +266,7 @@ where
             {
                 let mut g1_wnaf = g1_wnaf.shared();
 
-                scope.spawn(move |_scope| {
+                scope.execute(move || {
                     // Set values of the H query to g1^{(tau^i * t(tau)) / delta}
                     for (h, p) in h.iter_mut().zip(p.iter()) {
                         // Compute final exponent
@@ -346,7 +346,7 @@ where
                 let mut g1_wnaf = g1_wnaf.shared();
                 let mut g2_wnaf = g2_wnaf.shared();
 
-                scope.spawn(move |_scope| {
+                scope.execute(move || {
                     for ((((((a, b_g1), b_g2), ext), at), bt), ct) in a
                         .iter_mut()
                         .zip(b_g1.iter_mut())

--- a/src/groth16/mapped_params.rs
+++ b/src/groth16/mapped_params.rs
@@ -1,5 +1,6 @@
 use crate::bls::Engine;
 use groupy::{CurveAffine, EncodedPoint};
+use rayon::prelude::*;
 
 use crate::SynthesisError;
 

--- a/src/groth16/mapped_params.rs
+++ b/src/groth16/mapped_params.rs
@@ -6,7 +6,6 @@ use rayon::prelude::*;
 use crate::SynthesisError;
 
 use memmap::Mmap;
-use rayon::prelude::*;
 
 use std::fs::File;
 use std::io;

--- a/src/groth16/mapped_params.rs
+++ b/src/groth16/mapped_params.rs
@@ -1,5 +1,6 @@
 use crate::bls::Engine;
 use groupy::{CurveAffine, EncodedPoint};
+use log::info;
 use rayon::prelude::*;
 
 use crate::SynthesisError;
@@ -59,6 +60,7 @@ impl<'a, E: Engine> ParameterSource<E> for &'a MappedParameters<E> {
     }
 
     fn get_h(&self, _num_h: usize) -> Result<Self::G1Builder, SynthesisError> {
+        info!("get_h:start");
         let builder = self
             .h
             .par_iter()
@@ -66,17 +68,19 @@ impl<'a, E: Engine> ParameterSource<E> for &'a MappedParameters<E> {
             .map(|h| read_g1::<E>(&self.params, h, self.checked))
             .collect::<Result<_, _>>()?;
 
+        info!("get_h:end");
         Ok((Arc::new(builder), 0))
     }
 
     fn get_l(&self, _num_l: usize) -> Result<Self::G1Builder, SynthesisError> {
+        info!("get_l:start");
         let builder = self
             .l
             .par_iter()
             .cloned()
             .map(|l| read_g1::<E>(&self.params, l, self.checked))
             .collect::<Result<_, _>>()?;
-
+        info!("get_l:end");
         Ok((Arc::new(builder), 0))
     }
 
@@ -85,6 +89,7 @@ impl<'a, E: Engine> ParameterSource<E> for &'a MappedParameters<E> {
         num_inputs: usize,
         _num_a: usize,
     ) -> Result<(Self::G1Builder, Self::G1Builder), SynthesisError> {
+        info!("get_a:start");
         let builder = self
             .a
             .par_iter()
@@ -93,6 +98,7 @@ impl<'a, E: Engine> ParameterSource<E> for &'a MappedParameters<E> {
             .collect::<Result<_, _>>()?;
 
         let builder: Arc<Vec<_>> = Arc::new(builder);
+        info!("get_a:end");
 
         Ok(((builder.clone(), 0), (builder, num_inputs)))
     }
@@ -102,6 +108,7 @@ impl<'a, E: Engine> ParameterSource<E> for &'a MappedParameters<E> {
         num_inputs: usize,
         _num_b_g1: usize,
     ) -> Result<(Self::G1Builder, Self::G1Builder), SynthesisError> {
+        info!("get_b_g1:start");
         let builder = self
             .b_g1
             .par_iter()
@@ -110,7 +117,7 @@ impl<'a, E: Engine> ParameterSource<E> for &'a MappedParameters<E> {
             .collect::<Result<_, _>>()?;
 
         let builder: Arc<Vec<_>> = Arc::new(builder);
-
+        info!("get_b_g1:end");
         Ok(((builder.clone(), 0), (builder, num_inputs)))
     }
 
@@ -119,6 +126,7 @@ impl<'a, E: Engine> ParameterSource<E> for &'a MappedParameters<E> {
         num_inputs: usize,
         _num_b_g2: usize,
     ) -> Result<(Self::G2Builder, Self::G2Builder), SynthesisError> {
+        info!("get_b_g2:start");
         let builder = self
             .b_g2
             .par_iter()
@@ -127,7 +135,7 @@ impl<'a, E: Engine> ParameterSource<E> for &'a MappedParameters<E> {
             .collect::<Result<_, _>>()?;
 
         let builder: Arc<Vec<_>> = Arc::new(builder);
-
+        info!("get_b_g2:end");
         Ok(((builder.clone(), 0), (builder, num_inputs)))
     }
 }

--- a/src/groth16/proof.rs
+++ b/src/groth16/proof.rs
@@ -80,12 +80,13 @@ impl<E: Engine> Proof<E> {
     }
 
     pub fn read_many(proof_bytes: &[u8], num_proofs: usize) -> io::Result<Vec<Self>> {
-        use crate::multicore::THREAD_POOL;
+        use crate::multicore::RAYON_THREAD_POOL;
         use rayon::prelude::*;
+
         debug_assert_eq!(proof_bytes.len(), num_proofs * Self::size());
 
         // Decompress and group check in parallel
-        THREAD_POOL.install(|| {
+        RAYON_THREAD_POOL.install(|| {
             #[derive(Clone, Copy)]
             enum ProofPart<E: Engine> {
                 A(E::G1Affine),

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -4,8 +4,6 @@ use std::time::Instant;
 use ff::{Field, PrimeField};
 use groupy::{CurveAffine, CurveProjective};
 use log::info;
-#[cfg(feature = "gpu")]
-use log::trace;
 use rand_core::RngCore;
 use rayon::prelude::*;
 
@@ -321,7 +319,7 @@ where
     // multiexp calculations. This is what the `Worker` is used for. It is important that calling
     // `wait()` on the worker happens *outside* the thread pool, else deadlocks can happen.
     let worker = Worker::new();
-    let input_len = input_assignments[0].len();
+    let input_len = provers[0].input_assignment.len();
     let vk = params.get_vk(input_len)?.clone();
     let n = provers[0].a.len();
     let a_aux_density_total = provers[0].a_aux_density.get_total_density();

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use super::{ParameterSource, Proof};
 use crate::domain::{EvaluationDomain, Scalar};
 use crate::gpu::{LockedFFTKernel, LockedMultiexpKernel};
-use crate::multicore::{Worker, THREAD_POOL};
+use crate::multicore::{Worker, RAYON_THREAD_POOL};
 use crate::multiexp::{multiexp, DensityTracker, FullDensity};
 use crate::{
     Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable, BELLMAN_VERSION,
@@ -278,7 +278,7 @@ where
     // Preparing things for the proofs is done a lot in parallel with the help of Rayon. Make
     // sure that those things run on the correct thread pool.
     let (start, mut provers, input_assignments, aux_assignments) =
-        THREAD_POOL.install(|| create_proof_batch_priority_inner(circuits))?;
+        RAYON_THREAD_POOL.install(|| create_proof_batch_priority_inner(circuits))?;
 
     // The rest of the proving also has parallelism, but not on the outer loops, but within e.g. the
     // multiexp calculations. This is what the `Worker` is used for. It is important that calling

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -279,12 +279,12 @@ where
 
     info!("proofs");
     let proofs = gs
-        .into_par_iter()
-        .zip(h_s.into_par_iter())
-        .zip(l_s.into_par_iter())
-        .zip(r_s.into_par_iter())
-        .zip(s_s.into_par_iter())
-        .zip(inputs.into_par_iter())
+        .into_iter()
+        .zip(h_s.into_iter())
+        .zip(l_s.into_iter())
+        .zip(r_s.into_iter())
+        .zip(s_s.into_iter())
+        .zip(inputs.into_iter())
         .map(
             |(
                 (((((mut g_a, mut g_b, mut g_c), h), l), r), s),

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -322,25 +322,40 @@ where
             let mut c =
                 EvaluationDomain::from_coeffs(std::mem::replace(&mut prover.c, Vec::new()))?;
 
-            a.ifft(&worker, &mut fft_kern)?;
-            a.coset_fft(&worker, &mut fft_kern)?;
-            b.ifft(&worker, &mut fft_kern)?;
-            b.coset_fft(&worker, &mut fft_kern)?;
-            c.ifft(&worker, &mut fft_kern)?;
-            c.coset_fft(&worker, &mut fft_kern)?;
+            // execute 1 fft on the CPU, and 2 on the GPU if enabled
+            let (a_res, bc_res) = rayon::join(
+                || {
+                    a.ifft(&worker, &mut None)?;
+                    a.coset_fft(&worker, &mut None)
+                },
+                || {
+                    b.ifft(&worker, &mut fft_kern)?;
+                    b.coset_fft(&worker, &mut fft_kern)?;
+
+                    c.ifft(&worker, &mut fft_kern)?;
+                    c.coset_fft(&worker, &mut fft_kern)
+                },
+            );
+            a_res?;
+            bc_res?;
 
             a.mul_assign(&worker, &b);
-            drop(b);
             a.sub_assign(&worker, &c);
+
+            drop(b);
             drop(c);
+
             a.divide_by_z_on_coset(&worker);
             a.icoset_fft(&worker, &mut fft_kern)?;
-            let mut a = a.into_coeffs();
+
+            let a = a.into_coeffs();
             let a_len = a.len() - 1;
-            a.truncate(a_len);
 
             Ok(Arc::new(
-                a.into_iter().map(|s| s.0.into_repr()).collect::<Vec<_>>(),
+                a.into_iter()
+                    .take(a_len)
+                    .map(|s| s.0.into_repr())
+                    .collect::<Vec<_>>(),
             ))
         })
         .collect::<Result<Vec<_>, SynthesisError>>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,10 @@ pub mod multicore;
 pub mod multiexp;
 
 pub mod util_cs;
+
+#[macro_use]
+pub(crate) mod macros;
+
 use ff::{Field, ScalarEngine};
 
 use rustc_hash::FxHashMap as HashMap;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,39 @@
+#[macro_export]
+macro_rules! par {
+    ($(let $name:ident = $f:expr),+) => {
+        $(
+            let mut $name = None;
+        )+
+            rayon::scope(|s| {
+                $(
+                    let $name = &mut $name;
+                    s.spawn(move |_| {
+                        *$name = Some($f);
+                    });)+
+            });
+        $(
+            let $name = $name.unwrap();
+        )+
+    };
+
+    ($(let ($name1:ident, $name2:ident) = $f:block),+) => {
+        $(
+            let mut $name1 = None;
+            let mut $name2 = None;
+        )+
+            rayon::scope(|s| {
+                $(
+                    let $name1 = &mut $name1;
+                    let $name2 = &mut $name2;
+                    s.spawn(move |_| {
+                        let (a, b) = $f;
+                        *$name1 = Some(a);
+                        *$name2 = Some(b);
+                    });)+
+            });
+        $(
+            let $name1 = $name1.unwrap();
+            let $name2 = $name2.unwrap();
+        )+
+    }
+}

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -7,7 +7,6 @@
 
 use std::env;
 
-use crossbeam_channel::{bounded, Receiver};
 use lazy_static::lazy_static;
 use yastl::Pool;
 

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -17,7 +17,7 @@ lazy_static! {
     static ref NUM_CPUS: usize = env::var("BELLMAN_NUM_CPUS")
         .ok()
         .and_then(|num| num.parse().ok())
-        .unwrap_or_else(|| num_cpus::get());
+        .unwrap_or_else(num_cpus::get);
     pub static ref THREAD_POOL: Pool = Pool::new(*NUM_CPUS);
     pub static ref VERIFIER_POOL: Pool = Pool::new(NUM_CPUS.max(MAX_VERIFIER_THREADS));
     pub static ref RAYON_THREAD_POOL: rayon::ThreadPool = rayon::ThreadPoolBuilder::new()

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -50,25 +50,6 @@ impl Worker {
     }
 }
 
-pub struct Waiter<T> {
-    receiver: Receiver<T>,
-}
-
-impl<T> Waiter<T> {
-    /// Wait for the result.
-    pub fn wait(&self) -> T {
-        self.receiver.recv().unwrap()
-    }
-
-    /// One off sending.
-    pub fn done(val: T) -> Self {
-        let (sender, receiver) = bounded(1);
-        sender.send(val).unwrap();
-
-        Waiter { receiver }
-    }
-}
-
 fn log2_floor(num: usize) -> u32 {
     assert!(num > 0);
 

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -5,35 +5,25 @@
 //!
 //! [`CpuPool`]: futures_cpupool::CpuPool
 
-use crossbeam_channel::{bounded, Receiver};
-use lazy_static::lazy_static;
-use log::{error, trace};
 use std::env;
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use crossbeam_channel::{bounded, Receiver};
+use lazy_static::lazy_static;
+use yastl::Pool;
 
-static WORKER_SPAWN_COUNTER: AtomicUsize = AtomicUsize::new(0);
+const MAX_VERIFIER_THREADS: usize = 6;
 
 lazy_static! {
-    static ref NUM_CPUS: usize = if let Ok(num) = env::var("BELLMAN_NUM_CPUS") {
-        if let Ok(num) = num.parse() {
-            num
-        } else {
-            num_cpus::get()
-        }
-    } else {
-        num_cpus::get()
-    };
-    // See Worker::compute below for a description of this.
-    static ref WORKER_SPAWN_MAX_COUNT: usize = *NUM_CPUS * 4;
-    pub static ref THREAD_POOL: rayon::ThreadPool = rayon::ThreadPoolBuilder::new()
+    static ref NUM_CPUS: usize = env::var("BELLMAN_NUM_CPUS")
+        .ok()
+        .and_then(|num| num.parse().ok())
+        .unwrap_or_else(|| num_cpus::get());
+    pub static ref THREAD_POOL: Pool = Pool::new(*NUM_CPUS);
+    pub static ref VERIFIER_POOL: Pool = Pool::new(NUM_CPUS.max(MAX_VERIFIER_THREADS));
+    pub static ref RAYON_THREAD_POOL: rayon::ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(*NUM_CPUS)
         .build()
-        .unwrap();
-    pub static ref VERIFIER_POOL: rayon::ThreadPool = rayon::ThreadPoolBuilder::new()
-        .num_threads(NUM_CPUS.max(6))
-        .build()
-        .unwrap();
+        .expect("failed to build rayon threadpool");
 }
 
 #[derive(Clone, Default)]
@@ -55,52 +45,17 @@ impl Worker {
     {
         let (sender, receiver) = bounded(1);
 
-        let thread_index = if THREAD_POOL.current_thread_index().is_some() {
-            THREAD_POOL.current_thread_index().unwrap()
-        } else {
-            0
-        };
-
-        // We keep track here of how many times spawn has been called.
-        // It can be called without limit, each time, putting a
-        // request for a new thread to execute a method on the
-        // ThreadPool.  However, if we allow it to be called without
-        // limits, we run the risk of memory exhaustion due to limited
-        // stack space consumed by all of the pending closures to be
-        // executed.
-        let previous_count = WORKER_SPAWN_COUNTER.fetch_add(1, Ordering::SeqCst);
-
-        // If the number of spawns requested has exceeded the number
-        // of cores available for processing by some factor (the
-        // default being 4), instead of requesting that we spawn a new
-        // thread, we instead execute the closure in the context of an
-        // install call to help clear the growing work queue and
-        // minimize the chances of memory exhaustion.
-        if previous_count > *WORKER_SPAWN_MAX_COUNT {
-            THREAD_POOL.install(move || {
-                trace!("[{}] switching to install to help clear backlog[current threads {}, threads requested {}]",
-                       thread_index,
-                       THREAD_POOL.current_num_threads(),
-                       WORKER_SPAWN_COUNTER.load(Ordering::SeqCst));
-                let res = f();
-                sender.send(res).unwrap();
-                WORKER_SPAWN_COUNTER.fetch_sub(1, Ordering::SeqCst);
-            });
-        } else {
-            THREAD_POOL.spawn(move || {
-                let res = f();
-                sender.send(res).unwrap();
-                WORKER_SPAWN_COUNTER.fetch_sub(1, Ordering::SeqCst);
-            });
-        }
+        THREAD_POOL.spawn(move || {
+            let res = f();
+            sender.send(res).unwrap();
+        });
 
         Waiter { receiver }
     }
 
     pub fn scope<'a, F, R>(&self, elements: usize, f: F) -> R
     where
-        F: FnOnce(&rayon::Scope<'a>, usize) -> R + Send,
-        R: Send,
+        F: FnOnce(&yastl::Scope<'a>, usize) -> R,
     {
         let chunk_size = if elements < *NUM_CPUS {
             1
@@ -108,7 +63,7 @@ impl Worker {
             elements / *NUM_CPUS
         };
 
-        THREAD_POOL.scope(|scope| f(scope, chunk_size))
+        THREAD_POOL.scoped(|scope| f(scope, chunk_size))
     }
 }
 
@@ -119,11 +74,6 @@ pub struct Waiter<T> {
 impl<T> Waiter<T> {
     /// Wait for the result.
     pub fn wait(&self) -> T {
-        if THREAD_POOL.current_thread_index().is_some() {
-            // Calling `wait()` from within the worker thread pool can lead to dead logs
-            error!("The wait call should never be done inside the worker thread pool");
-            debug_assert!(false);
-        }
         self.receiver.recv().unwrap()
     }
 

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -10,6 +10,7 @@ use rayon::prelude::*;
 
 use super::SynthesisError;
 use crate::gpu;
+use crate::multicore::THREAD_POOL;
 
 /// An object that builds a source of bases.
 pub trait SourceBuilder<G: CurveAffine>: Send + Sync + 'static + Clone {
@@ -328,7 +329,7 @@ where
         assert!(query_size == exponents.len());
     }
 
-    multiexp_inner(bases, density_map, exponents, c)
+    THREAD_POOL.install(|| multiexp_inner(bases, density_map, exponents, c))
 }
 
 #[cfg(any(feature = "pairing", feature = "blst"))]

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 
 use super::SynthesisError;
 use crate::gpu;
-use crate::multicore::THREAD_POOL;
+use crate::multicore::RAYON_THREAD_POOL;
 
 /// An object that builds a source of bases.
 pub trait SourceBuilder<G: CurveAffine>: Send + Sync + 'static + Clone {
@@ -311,7 +311,7 @@ where
             }
 
             let (bss, skip) = bases.clone().get();
-            k.multiexp(bss, Arc::new(exps.clone()), skip, n)
+            k.multiexp(bss, Arc::new(exps), skip, n)
         }) {
             return Ok(p);
         }
@@ -329,7 +329,7 @@ where
         assert!(query_size == exponents.len());
     }
 
-    THREAD_POOL.install(|| multiexp_inner(bases, density_map, exponents, c))
+    RAYON_THREAD_POOL.install(|| multiexp_inner(bases, density_map, exponents, c))
 }
 
 #[cfg(any(feature = "pairing", feature = "blst"))]


### PR DESCRIPTION
- parallelize loading mapped params
- load params in parallel while GPU work is being done, to avoid blocking later
- improve parallelism inside proving code to avoid bottlenecks

## Speed Improvements

on a benchmark machine using 1 RTX 3090 and 1 RTX 2080TI

- Generate PoRep: before: `2,283s`, after: `881s`
- Generate Window PoST: before: `321s`, after: `144s`