### PR TITLE
chore: upgrade to latest rust-gpu-tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ blstrs = { version = "0.1.3", optional = true }
 paired = { version = "0.21.0", optional = true }
 
 # gpu feature 
-rust-gpu-tools = { version = "0.2.0", optional = true }
+rust-gpu-tools = { version = "0.3.0", optional = true }
 ff-cl-gen = { version = "0.2.0", optional = true }
 fs2 = { version = "0.4.3", optional = true }
 

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -30,7 +30,7 @@ where
     pub fn create(priority: bool) -> GPUResult<FFTKernel<E>> {
         let lock = locks::GPULock::lock();
 
-        let devices = opencl::Device::all()?;
+        let devices = opencl::Device::all();
         if devices.is_empty() {
             return Err(GPUError::Simple("No working GPUs found!"));
         }

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -224,11 +224,11 @@ where
     pub fn create(priority: bool) -> GPUResult<MultiexpKernel<E>> {
         let lock = locks::GPULock::lock();
 
-        let devices = opencl::Device::all()?;
+        let devices = opencl::Device::all();
 
         let kernels: Vec<_> = devices
             .into_iter()
-            .map(|d| (d.clone(), SingleMultiexpKernel::<E>::create(d, priority)))
+            .map(|d| (d, SingleMultiexpKernel::<E>::create(d.clone(), priority)))
             .filter_map(|(device, res)| {
                 if let Err(ref e) = res {
                     error!(

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -74,7 +74,7 @@ pub fn get_core_count(d: &opencl::Device) -> usize {
 }
 
 pub fn dump_device_list() {
-    for d in opencl::Device::all().unwrap() {
+    for d in opencl::Device::all() {
         info!("Device: {:?}", d);
     }
 }


### PR DESCRIPTION
This change has nothing todo with my opencl3 work, it just updates to the latest ocl based version (to make future PRs simpler).