### PR TITLE
Enforce all-but-once randomization more generally.

### DIFF
--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -85,71 +85,74 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug, R: rand::RngCore + Se
         // NOTE: From this point on, we are only checking *one* pairing check so
         // we don't need to randomize as all other checks are being randomized
         // already so this is the "base check" so to speak.
-        pairing_checks_copy.merge_parts(
+        pairing_checks_copy.merge_pairing_equation(
             // 3. Compute left part of the final pairing equation
-            move || {
-                let mut alpha_g1_r_sum = pvk.alpha_g1;
-                alpha_g1_r_sum.mul_assign(r_sum);
-                let ml = E::miller_loop(&[(&alpha_g1_r_sum.into_affine().prepare(), &pvk.beta_g2)]);
+            vec![
+                {
+                    let mut alpha_g1_r_sum = pvk.alpha_g1;
+                    alpha_g1_r_sum.mul_assign(r_sum);
+                    let ml =
+                        E::miller_loop(&[(&alpha_g1_r_sum.into_affine().prepare(), &pvk.beta_g2)]);
 
-                ml
-            },
-            // 4. Compute right part of the final pairing equation
-            move || {
-                E::miller_loop(&[(
-                    // e(c^r vector form, h^delta)
-                    // let agg_c = inner_product::multiexponentiation::<E::G1Affine>(&c, r_vec)
-                    &proof.agg_c.into_affine().prepare(),
-                    &pvk.delta_g2,
-                )])
-            },
-            // 5. compute the middle part of the final pairing equation, the one
-            //    with the public inputs
-            move || {
-                // We want to compute MUL(i:0 -> l) S_i ^ (SUM(j:0 -> n) ai,j * r^j)
-                // this table keeps tracks of incremental computation of each i-th
-                // exponent to later multiply with S_i
-                // The index of the table is i, which is an index of the public
-                // input element
-                // We incrementally build the r vector and the table
-                // NOTE: in this version it's not r^2j but simply r^j
+                    ml
+                },
+                // 4. Compute right part of the final pairing equation
+                {
+                    E::miller_loop(&[(
+                        // e(c^r vector form, h^delta)
+                        // let agg_c = inner_product::multiexponentiation::<E::G1Affine>(&c, r_vec)
+                        &proof.agg_c.into_affine().prepare(),
+                        &pvk.delta_g2,
+                    )])
+                },
+                // 5. compute the middle part of the final pairing equation, the one
+                //    with the public inputs
+                {
+                    // We want to compute MUL(i:0 -> l) S_i ^ (SUM(j:0 -> n) ai,j * r^j)
+                    // this table keeps tracks of incremental computation of each i-th
+                    // exponent to later multiply with S_i
+                    // The index of the table is i, which is an index of the public
+                    // input element
+                    // We incrementally build the r vector and the table
+                    // NOTE: in this version it's not r^2j but simply r^j
 
-                let l = public_inputs[0].len();
-                let mut g_ic = pvk.ic_projective[0];
-                g_ic.mul_assign(r_sum);
+                    let l = public_inputs[0].len();
+                    let mut g_ic = pvk.ic_projective[0];
+                    g_ic.mul_assign(r_sum);
 
-                let powers = r_vec_receiver.recv().unwrap();
+                    let powers = r_vec_receiver.recv().unwrap();
 
-                let now = Instant::now();
-                // now we do the multi exponentiation
-                let getter = |i: usize| -> <E::Fr as PrimeField>::Repr {
-                    // i denotes the column of the public input, and j denotes which public input
-                    let mut c = public_inputs[0][i];
-                    for j in 1..public_inputs.len() {
-                        let mut ai = public_inputs[j][i];
-                        ai.mul_assign(&powers[j]);
-                        c.add_assign(&ai);
-                    }
-                    c.into_repr()
-                };
+                    let now = Instant::now();
+                    // now we do the multi exponentiation
+                    let getter = |i: usize| -> <E::Fr as PrimeField>::Repr {
+                        // i denotes the column of the public input, and j denotes which public input
+                        let mut c = public_inputs[0][i];
+                        for j in 1..public_inputs.len() {
+                            let mut ai = public_inputs[j][i];
+                            ai.mul_assign(&powers[j]);
+                            c.add_assign(&ai);
+                        }
+                        c.into_repr()
+                    };
 
-                let totsi = par_multiscalar::<_, E::G1Affine>(
-                    &ScalarList::Getter(getter, l),
-                    &pvk.multiscalar.at_point(1),
-                    std::mem::size_of::<<E::Fr as PrimeField>::Repr>() * 8,
-                );
+                    let totsi = par_multiscalar::<_, E::G1Affine>(
+                        &ScalarList::Getter(getter, l),
+                        &pvk.multiscalar.at_point(1),
+                        std::mem::size_of::<<E::Fr as PrimeField>::Repr>() * 8,
+                    );
 
-                g_ic.add_assign(&totsi);
+                    g_ic.add_assign(&totsi);
 
-                let ml = E::miller_loop(&[(&g_ic.into_affine().prepare(), &pvk.gamma_g2)]);
-                let elapsed = now.elapsed().as_millis();
-                debug!("table generation: {}ms", elapsed);
+                    let ml = E::miller_loop(&[(&g_ic.into_affine().prepare(), &pvk.gamma_g2)]);
+                    let elapsed = now.elapsed().as_millis();
+                    debug!("table generation: {}ms", elapsed);
 
-                ml
-            },
+                    ml
+                },
+            ],
             // final value ip_ab is what we want to compare in the groth16
             // aggregated equation A * B
-            || (E::Fqk::one(), proof.ip_ab.clone()),
+            (E::Fqk::one(), proof.ip_ab.clone()),
         );
     });
 


### PR DESCRIPTION
This is an incremental refactor of the work in #167.

It moves tracking of randomization into`PairingCheck`, where it belongs. It also refactors `merge_parts` to the more general `merge_equation` and adjusts tracking of the need for randomization atomically — so all checks merged in a single operation either require randomization or not. This allows the Groth16 equation to be exempted (once) just as we want. Likewise, `PairingChecks` now tracks precisely whether or not it has absorbed any non-random `PairingCheck`s. So the only way to successfully merge non-random `PairingCheck`s is in a single operation. In the case of our verification routines, this is done with `merge_equation` — but there is nothing to stop callers from accurately using `merge_one` (once) or any of the other `merge_…` functions (except that they're not currently public).

Although this adds a bit more tracking, I think it raises these operations to being general purpose, which makes it easier to reason about them and expect them to behave correctly. From my perspective, that is the goal.

In order to keep this simple, I removed the separate threads for each component of the Groth16 equation, and as far as I could tell, this didn't harm performance — so I left it. See benchmarks below.

If it turns out performance isn't good enough, I think we can probably keep the basic structure here and rearrange to reintroduce the parallelism — but I'm hoping that the performance I'm observing is fine.

The benchmarks are a bit noisy for me, since even with the same code I'm seeing quite a lot of variation between runs, but here's the most recent one I ran — which seems comparable to or better than other versions I've seen on different branches:

```
nproofs,aggregate_create_ms,aggregate_verify_ms,batch_verify_ms,batch_all_ms,aggregate_size_bytes,batch_size_bytes
8,62,28,6,15,11220,1536
16,97,31,6,36,14196,3072
32,157,32,7,67,17172,6144
64,237,35,12,114,20148,12288
128,393,38,18,205,23124,24576
256,576,39,28,356,26100,49152
512,967,28,49,484,29076,98304
1024,1856,27,88,958,32052,196608
2048,3149,30,152,1837,35028,393216
4096,6109,47,298,3788,38004,786432
8192,11472,49,589,7346,40980,1572864
```