### PR TITLE
IPP - Same base as in the paper

### DIFF
--- a/src/groth16/aggregate/accumulator.rs
+++ b/src/groth16/aggregate/accumulator.rs
@@ -52,7 +52,6 @@ where
     where
         I: IntoIterator<Item = &'a (&'a E::G1Affine, &'a E::G2Affine)>,
     {
-        //let mut rng = thread_rng();
         let mut rng: OsRng = Default::default();
         let coeff = E::Fr::random(&mut rng);
         assert!(coeff != E::Fr::zero());
@@ -79,8 +78,17 @@ where
     pub fn merge(&mut self, p2: &PairingCheck<E>) {
         // multiply miller loop results together
         self.0.mul_assign(&p2.0);
-        // multiply  right side in GT together
-        self.1.mul_assign(&p2.1);
+        // multiply right side in GT together
+        if p2.1 != E::Fqk::one() {
+            if self.1 != E::Fqk::one() {
+                // if both sides are not one, then multiply
+                self.1.mul_assign(&p2.1);
+            } else {
+                // otherwise, only keep the side which is not one
+                self.1 = p2.1.clone();
+            }
+        }
+        // if p2.1 is one, then we don't need to change anything.
     }
 
     pub fn verify(&self) -> bool {

--- a/src/groth16/aggregate/accumulator.rs
+++ b/src/groth16/aggregate/accumulator.rs
@@ -1,14 +1,13 @@
-use ff::{Field, PrimeField};
-use groupy::{CurveAffine, CurveProjective};
-use rand::thread_rng;
-
-#[cfg(feature = "pairing")]
-use paired::{Engine, PairingCurveAffine};
-
 #[cfg(feature = "blst")]
 use crate::bls::Engine;
 #[cfg(feature = "blst")]
 use blstrs::PairingCurveAffine;
+use core::default::Default;
+use ff::{Field, PrimeField};
+use groupy::{CurveAffine, CurveProjective};
+#[cfg(feature = "pairing")]
+use paired::{Engine, PairingCurveAffine};
+use rand::rngs::OsRng;
 
 /// PairingCheck represents a check of the form e(A,B)e(C,D)... = T. Checks can
 /// be aggregated together using random linear combination. The efficiency comes
@@ -53,7 +52,8 @@ where
     where
         I: IntoIterator<Item = &'a (&'a E::G1Affine, &'a E::G2Affine)>,
     {
-        let mut rng = thread_rng();
+        //let mut rng = thread_rng();
+        let mut rng: OsRng = Default::default();
         let coeff = E::Fr::random(&mut rng);
         assert!(coeff != E::Fr::zero());
         let pairs = it

--- a/src/groth16/aggregate/accumulator.rs
+++ b/src/groth16/aggregate/accumulator.rs
@@ -2,6 +2,7 @@ use crate::bls::Engine;
 use ff::{Field, PrimeField};
 use groupy::{CurveAffine, CurveProjective};
 use paired::PairingCurveAffine;
+use rand::rngs::OsRng;
 use rand::thread_rng;
 
 /// PairingCheck represents a check of the form e(A,B)e(C,D)... = T. Checks can
@@ -49,6 +50,7 @@ where
     {
         let mut rng = thread_rng();
         let coeff = E::Fr::random(&mut rng);
+        assert!(coeff != E::Fr::zero());
         let pairs = it
             .into_iter()
             .map(|&(a, b)| {

--- a/src/groth16/aggregate/accumulator.rs
+++ b/src/groth16/aggregate/accumulator.rs
@@ -15,10 +15,13 @@ use std::sync::{
     Arc, Mutex,
 };
 
+#[derive(Debug)]
 pub struct PairingChecks<E: Engine, R: rand::RngCore + Send> {
+    /// Circuit breaker to allow canceling all checks and marking the whole check as failed.
     valid: Arc<AtomicBool>,
     merge_send: Sender<PairingCheck<E>>,
     valid_recv: Receiver<bool>,
+    /// Random number generator used for generating the random coefficients.
     rng: Mutex<R>,
     /// Ensures that the non randomized check is only added exactly once.
     non_random_check_done: AtomicBool,
@@ -128,6 +131,7 @@ impl<E: Engine, R: rand::RngCore + Send> PairingChecks<E, R> {
 /// before going into a final exponentiation result
 /// - a right side result which is already in the right subgroup Gt which is to
 /// be compared to the left side when "final_exponentiatiat"-ed
+#[derive(Debug)]
 struct PairingCheck<E: Engine> {
     left: E::Fqk,
     right: E::Fqk,

--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -476,7 +476,7 @@ pub fn verify_kzg_opening_g2<E: Engine, R: rand::RngCore + Send>(
             // uH - f_v(z)H = (u - f_v)H --> v1h^{-af_v(z)}
             &sub!(
                 final_vkey.0.into_projective(),
-                &mul!(v_srs.h_alpha, vpoly_eval_z)
+                &mul!(v_srs.h, vpoly_eval_z)
             )
             .into_affine(),
         ),
@@ -495,7 +495,7 @@ pub fn verify_kzg_opening_g2<E: Engine, R: rand::RngCore + Send>(
             // uH - f_v(z)H = (u - f_v)H --> v1h^{-f_v(z)}
             &sub!(
                 final_vkey.1.into_projective(),
-                &mul!(v_srs.h_beta, vpoly_eval_z)
+                &mul!(v_srs.h, vpoly_eval_z)
             )
             .into_affine(),
         ),
@@ -529,7 +529,7 @@ pub fn verify_kzg_opening_g1<E: Engine, R: rand::RngCore + Send>(
 
     par! {
         // first check on w1
-        // let K = g^{a^{n+1}}
+        // let K = g^{a^n}
         // e(w1 K^{-f_w(z)},h)
         let _check1 = pairing_checks.merge_miller_inputs(&[(
             &sub!(
@@ -546,7 +546,7 @@ pub fn verify_kzg_opening_g1<E: Engine, R: rand::RngCore + Send>(
                 .into_affine(),
         )], &E::Fqk::one()),
         // then do second check
-        // let K = g^{b^{n+1}}
+        // let K = g^{b^{n}}
         // e(w2 K^{-f_w(z)},h)
         let _check2 = pairing_checks.merge_miller_inputs(&[(
             &sub!(

--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -248,12 +248,12 @@ fn verify_tipp_mipp<E: Engine>(
         //
         // TIPP
         // z = e(A,B)
-        let check_z = PairingCheck::<E>::from_miller_inputs(&[(final_a, &final_b.prepare())], final_zab),
+        let check_z = PairingCheck::<E>::from_miller_inputs(&[(final_a, final_b)], final_zab),
         //  final_aB.0 = T = e(A,v1)e(w1,B)
-        let check_ab0 = PairingCheck::<E>::from_miller_inputs(&[(final_a, &fvkey.0.prepare()),(&fwkey.0, &final_b.prepare())], final_tab),
+        let check_ab0 = PairingCheck::<E>::from_miller_inputs(&[(final_a, &fvkey.0),(&fwkey.0, final_b)], final_tab),
 
         //  final_aB.1 = U = e(A,v2)e(w2,B)
-        let check_ab1 = PairingCheck::<E>::from_miller_inputs(&[(final_a, &fvkey.1.prepare()),(&fwkey.1, &final_b.prepare())], final_uab),
+        let check_ab1 = PairingCheck::<E>::from_miller_inputs(&[(final_a, &fvkey.1),(&fwkey.1, final_b)], final_uab),
 
         // MIPP
         // Verify base inner product commitment
@@ -263,9 +263,9 @@ fn verify_tipp_mipp<E: Engine>(
             &[final_r.clone()]),
         // Check commiment correctness
         // T = e(C,v1)
-        let check_t = PairingCheck::<E>::from_miller_inputs(&[(final_c,&fvkey.0.prepare())],final_tc),
+        let check_t = PairingCheck::<E>::from_miller_inputs(&[(final_c,&fvkey.0)],final_tc),
         // U = e(A,v2)
-        let check_u = PairingCheck::<E>::from_miller_inputs(&[(final_c,&fvkey.1.prepare())],final_uc)
+        let check_u = PairingCheck::<E>::from_miller_inputs(&[(final_c,&fvkey.1)],final_uc)
     };
 
     debug!(

--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 use sha2::Sha256;
 
 use super::{
-    accumulator::PairingCheck, inner_product,
+    accumulator::PairingChecks, inner_product,
     prove::polynomial_evaluation_product_form_from_transcript, structured_scalar_power,
     AggregateProof, KZGOpening, VerifierSRS,
 };
@@ -22,9 +22,10 @@ use crate::SynthesisError;
 use std::default::Default;
 use std::time::Instant;
 
-pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug>(
+pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug, R: rand::RngCore + Send>(
     ip_verifier_srs: &VerifierSRS<E>,
     pvk: &PreparedVerifyingKey<E>,
+    rng: R,
     public_inputs: &[Vec<E::Fr>],
     proof: &AggregateProof<E>,
 ) -> Result<bool, SynthesisError> {
@@ -44,23 +45,21 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug>(
         }
     }
 
-    let (valid_send, valid_rcv) = bounded(1);
-    rayon::scope(move |s| {
-        // channel used to aggregate all pairing tuples
-        let (send_tuple, rcv_tuple) = bounded(10);
+    let pairing_checks = PairingChecks::new(rng);
+    let pairing_checks_copy = &pairing_checks;
 
+    rayon::scope(move |s| {
         // 1.Check TIPA proof ab
         // 2.Check TIPA proof c
-        let tipa_ab = send_tuple.clone();
         s.spawn(move |_| {
             let now = Instant::now();
-            let tuple = verify_tipp_mipp::<E>(
+            verify_tipp_mipp::<E, R>(
                 ip_verifier_srs,
                 proof,
                 &r, // we give the extra r as it's not part of the proof itself - it is simply used on top for the groth16 aggregation
+                pairing_checks_copy,
             );
             debug!("TIPP took {} ms", now.elapsed().as_millis(),);
-            tipa_ab.send(tuple).unwrap();
         });
 
         // Check aggregate pairing product equation
@@ -78,28 +77,23 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug>(
         // NOTE From this point on, we are only checking *one* pairing check so
         // we don't need to randomize as all other checks are being randomized
         // already so this is the "base check" so to speak.
-        let p1 = send_tuple.clone();
         s.spawn(move |_| {
             let mut alpha_g1_r_sum = pvk.alpha_g1;
             alpha_g1_r_sum.mul_assign(r_sum);
-            let tuple = PairingCheck::<E>::from_miller_one(E::miller_loop(&[(
+            pairing_checks_copy.merge_miller_one(E::miller_loop(&[(
                 &alpha_g1_r_sum.into_affine().prepare(),
                 &pvk.beta_g2,
             )]));
-
-            p1.send(tuple).unwrap();
         });
 
         // 4. Compute right part of the final pairing equation
-        let p3 = send_tuple.clone();
         s.spawn(move |_| {
-            let tuple = PairingCheck::from_miller_one(E::miller_loop(&[(
+            pairing_checks_copy.merge_miller_one(E::miller_loop(&[(
                 // e(c^r vector form, h^delta)
                 // let agg_c = inner_product::multiexponentiation::<E::G1Affine>(&c, r_vec)
                 &proof.agg_c.into_affine().prepare(),
                 &pvk.delta_g2,
             )]));
-            p3.send(tuple).unwrap();
         });
 
         let (r_vec_sender, r_vec_receiver) = bounded(1);
@@ -114,7 +108,6 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug>(
 
         // 5. compute the middle part of the final pairing equation, the one
         //    with the public inputs
-        //let p2 = send_tuple.clone();
         s.spawn(move |_| {
             // We want to compute MUL(i:0 -> l) S_i ^ (SUM(j:0 -> n) ai,j * r^j)
             // this table keeps tracks of incremental computation of each i-th
@@ -151,28 +144,20 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug>(
 
             g_ic.add_assign(&totsi);
 
-            let tuple = PairingCheck::from_miller_one(E::miller_loop(&[(
+            pairing_checks_copy.merge_miller_one(E::miller_loop(&[(
                 &g_ic.into_affine().prepare(),
                 &pvk.gamma_g2,
             )]));
             let elapsed = now.elapsed().as_millis();
             debug!("table generation: {}ms", elapsed);
-
-            send_tuple.send(tuple).unwrap();
         });
 
-        s.spawn(move |_| {
-            // final value ip_ab is what we want to compare in the groth16
-            // aggregated equation A * B
-            let mut acc = PairingCheck::from_pair(E::Fqk::one(), proof.ip_ab.clone());
-            while let Ok(tuple) = rcv_tuple.recv() {
-                acc.merge(&tuple);
-            }
-            valid_send.send(acc.verify()).unwrap();
-        });
+        // final value ip_ab is what we want to compare in the groth16
+        // aggregated equation A * B
+        pairing_checks_copy.merge_pair(E::Fqk::one(), proof.ip_ab.clone());
     });
 
-    let res = valid_rcv.recv().unwrap();
+    let res = pairing_checks.verify();
     info!("aggregate verify done");
 
     Ok(res)
@@ -181,11 +166,12 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug>(
 /// verify_tipp_mipp returns a pairing equation to check the tipp proof.  $r$ is
 /// the randomness used to produce a random linear combination of A and B and
 /// used in the MIPP part with C
-fn verify_tipp_mipp<E: Engine>(
+fn verify_tipp_mipp<E: Engine, R: rand::RngCore + Send>(
     v_srs: &VerifierSRS<E>,
     proof: &AggregateProof<E>,
     r_shift: &E::Fr,
-) -> PairingCheck<E> {
+    pairing_checks: &PairingChecks<E, R>,
+) {
     info!("verify with srs shift");
     let now = Instant::now();
     // (T,U), Z for TIPP and MIPP  and all challenges
@@ -225,22 +211,24 @@ fn verify_tipp_mipp<E: Engine>(
     let now = Instant::now();
     par! {
         // check the opening proof for v
-        let vtuple = verify_kzg_opening_g2(
+        let _vtuple = verify_kzg_opening_g2(
             v_srs,
             &fvkey,
             &proof.tmipp.vkey_opening,
             &challenges_inv,
             &E::Fr::one(),
             &c,
+            pairing_checks,
         ),
         // check the opening proof for w - note that w has been rescaled by $r^{-1}$
-        let wtuple = verify_kzg_opening_g1(
+        let _wtuple = verify_kzg_opening_g1(
             v_srs,
             &fwkey,
             &proof.tmipp.wkey_opening,
             &challenges,
             &r_shift.inverse().unwrap(),
             &c,
+            pairing_checks,
         ),
         //
         // We create a sequence of pairing tuple that we aggregate together at
@@ -248,12 +236,12 @@ fn verify_tipp_mipp<E: Engine>(
         //
         // TIPP
         // z = e(A,B)
-        let check_z = PairingCheck::<E>::from_miller_inputs(&[(final_a, final_b)], final_zab),
+        let _check_z = pairing_checks.merge_miller_inputs(&[(final_a, final_b)], final_zab),
         //  final_aB.0 = T = e(A,v1)e(w1,B)
-        let check_ab0 = PairingCheck::<E>::from_miller_inputs(&[(final_a, &fvkey.0),(&fwkey.0, final_b)], final_tab),
+        let _check_ab0 = pairing_checks.merge_miller_inputs(&[(final_a, &fvkey.0),(&fwkey.0, final_b)], final_tab),
 
         //  final_aB.1 = U = e(A,v2)e(w2,B)
-        let check_ab1 = PairingCheck::<E>::from_miller_inputs(&[(final_a, &fvkey.1),(&fwkey.1, final_b)], final_uab),
+        let _check_ab1 = pairing_checks.merge_miller_inputs(&[(final_a, &fvkey.1),(&fwkey.1, final_b)], final_uab),
 
         // MIPP
         // Verify base inner product commitment
@@ -263,9 +251,9 @@ fn verify_tipp_mipp<E: Engine>(
             &[final_r.clone()]),
         // Check commiment correctness
         // T = e(C,v1)
-        let check_t = PairingCheck::<E>::from_miller_inputs(&[(final_c,&fvkey.0)],final_tc),
+        let _check_t = pairing_checks.merge_miller_inputs(&[(final_c,&fvkey.0)],final_tc),
         // U = e(A,v2)
-        let check_u = PairingCheck::<E>::from_miller_inputs(&[(final_c,&fvkey.1)],final_uc)
+        let _check_u = pairing_checks.merge_miller_inputs(&[(final_c,&fvkey.1)],final_uc)
     };
 
     debug!(
@@ -277,18 +265,8 @@ fn verify_tipp_mipp<E: Engine>(
     // only check that doesn't require pairing so we can give a tuple that will
     // render the equation wrong in case it's false
     if !b {
-        return PairingCheck::new_invalid();
+        pairing_checks.invalidate();
     }
-    let now = Instant::now();
-    let mut acc = vtuple;
-    acc.merge(&check_z);
-    acc.merge(&check_ab0);
-    acc.merge(&check_ab1);
-    acc.merge(&check_t);
-    acc.merge(&check_u);
-    acc.merge(&wtuple);
-    debug!("TIPP verify: final merge {}ms", now.elapsed().as_millis());
-    acc
 }
 
 /// gipa_verify_tipp_mipp recurse on the proof and statement and produces the final
@@ -469,14 +447,15 @@ fn gipa_verify_tipp_mipp<E: Engine>(
 /// verify_kzg_opening_g2 takes a KZG opening, the final commitment key, SRS and
 /// any shift (in TIPP we shift the v commitment by r^-1) and returns a pairing
 /// tuple to check if the opening is correct or not.
-pub fn verify_kzg_opening_g2<E: Engine>(
+pub fn verify_kzg_opening_g2<E: Engine, R: rand::RngCore + Send>(
     v_srs: &VerifierSRS<E>,
     final_vkey: &(E::G2Affine, E::G2Affine),
     vkey_opening: &KZGOpening<E::G2Affine>,
     challenges: &[E::Fr],
     r_shift: &E::Fr,
     kzg_challenge: &E::Fr,
-) -> PairingCheck<E> {
+    pairing_checks: &PairingChecks<E, R>,
+) {
     // f_v(z)
     let vpoly_eval_z =
         polynomial_evaluation_product_form_from_transcript(challenges, kzg_challenge, r_shift);
@@ -488,7 +467,7 @@ pub fn verify_kzg_opening_g2<E: Engine>(
     par! {
         // verify first part of opening - v1
         // e(g, v1 h^{-af_v(z)})
-        let check1 = PairingCheck::<E>::from_miller_inputs(&[(
+        let _check1 = pairing_checks.merge_miller_inputs(&[(
             &ng.into_affine(),
             // in additive notation: final_vkey = uH,
             // uH - f_v(z)H = (u - f_v)H --> v1h^{-af_v(z)}
@@ -503,11 +482,11 @@ pub fn verify_kzg_opening_g2<E: Engine>(
             &sub!(v_srs.g_alpha, &mul!(v_srs.g, kzg_challenge.clone()))
                 .into_affine(),
             &vkey_opening.0,
-        )],&E::Fqk::one()),
+        )], &E::Fqk::one()),
 
         // verify second part of opening - v2 - similar but changing secret exponent
         // e(g, v2 h^{-bf_v(z)})
-        let check2 = PairingCheck::<E>::from_miller_inputs(&[(
+        let _check2 = pairing_checks.merge_miller_inputs(&[(
             &ng.into_affine(),
             // in additive notation: final_vkey = uH,
             // uH - f_v(z)H = (u - f_v)H --> v1h^{-f_v(z)}
@@ -522,22 +501,20 @@ pub fn verify_kzg_opening_g2<E: Engine>(
             &sub!(v_srs.g_beta, &mul!(v_srs.g, kzg_challenge.clone()))
                 .into_affine(),
             &vkey_opening.1,
-        )],&E::Fqk::one())
+        )], &E::Fqk::one())
     };
-    let mut final_check = check1;
-    final_check.merge(&check2);
-    final_check
 }
 
 /// Similar to verify_kzg_opening_g2 but for g1.
-pub fn verify_kzg_opening_g1<E: Engine>(
+pub fn verify_kzg_opening_g1<E: Engine, R: rand::RngCore + Send>(
     v_srs: &VerifierSRS<E>,
     final_wkey: &(E::G1Affine, E::G1Affine),
     wkey_opening: &KZGOpening<E::G1Affine>,
     challenges: &[E::Fr],
     r_shift: &E::Fr,
     kzg_challenge: &E::Fr,
-) -> PairingCheck<E> {
+    pairing_checks: &PairingChecks<E, R>,
+) {
     let wkey_poly_eval =
         polynomial_evaluation_product_form_from_transcript(challenges, kzg_challenge, r_shift);
 
@@ -551,7 +528,7 @@ pub fn verify_kzg_opening_g1<E: Engine>(
         // first check on w1
         // let K = g^{a^{n+1}}
         // e(w1 K^{-f_w(z)},h)
-        let check1 = PairingCheck::<E>::from_miller_inputs(&[(
+        let _check1 = pairing_checks.merge_miller_inputs(&[(
             &sub!(
                 final_wkey.0.into_projective(),
                 &mul!(v_srs.g_alpha_n1, wkey_poly_eval)
@@ -564,11 +541,11 @@ pub fn verify_kzg_opening_g1<E: Engine>(
             &wkey_opening.0,
             &sub!(v_srs.h_alpha, &mul!(v_srs.h, *kzg_challenge))
                 .into_affine(),
-        )],&E::Fqk::one()),
+        )], &E::Fqk::one()),
         // then do second check
         // let K = g^{b^{n+1}}
         // e(w2 K^{-f_w(z)},h)
-        let check2 = PairingCheck::<E>::from_miller_inputs(&[(
+        let _check2 = pairing_checks.merge_miller_inputs(&[(
             &sub!(
                 final_wkey.1.into_projective(),
                 &mul!(v_srs.g_beta_n1, wkey_poly_eval)
@@ -581,11 +558,8 @@ pub fn verify_kzg_opening_g1<E: Engine>(
             &wkey_opening.1,
             &sub!(v_srs.h_beta, &mul!(v_srs.h, *kzg_challenge))
                 .into_affine(),
-        )],&E::Fqk::one())
+        )], &E::Fqk::one())
     };
-    let mut final_check = check1;
-    final_check.merge(&check2);
-    final_check
 }
 
 /// Keeps track of the variables that have been sent by the prover and must

--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -488,50 +488,45 @@ pub fn verify_kzg_opening_g2<E: Engine>(
     par! {
         // verify first part of opening - v1
         // e(g, v1 h^{-af_v(z)})
-        let p1 = E::miller_loop(&[(
-            &ng.into_affine().prepare(),
+        let check1 = PairingCheck::<E>::from_miller_inputs(&[(
+            &ng.into_affine(),
             // in additive notation: final_vkey = uH,
             // uH - f_v(z)H = (u - f_v)H --> v1h^{-af_v(z)}
             &sub!(
                 final_vkey.0.into_projective(),
                 &mul!(v_srs.h_alpha, vpoly_eval_z)
             )
-            .into_affine()
-            .prepare(),
-        )]),
+            .into_affine(),
+        ),
         // e(g^{a - z}, opening_1) ==> (aG) - (zG)
-        let p2 = E::miller_loop(&[(
+        (
             &sub!(v_srs.g_alpha, &mul!(v_srs.g, kzg_challenge.clone()))
-                .into_affine()
-                .prepare(),
-            &vkey_opening.0.prepare(),
-        )]),
+                .into_affine(),
+            &vkey_opening.0,
+        )],&E::Fqk::one()),
 
         // verify second part of opening - v2 - similar but changing secret exponent
         // e(g, v2 h^{-bf_v(z)})
-        let q1 = E::miller_loop(&[(
-            &ng.into_affine().prepare(),
+        let check2 = PairingCheck::<E>::from_miller_inputs(&[(
+            &ng.into_affine(),
             // in additive notation: final_vkey = uH,
             // uH - f_v(z)H = (u - f_v)H --> v1h^{-f_v(z)}
             &sub!(
                 final_vkey.1.into_projective(),
                 &mul!(v_srs.h_beta, vpoly_eval_z)
             )
-            .into_affine()
-            .prepare(),
-        )]),
+            .into_affine(),
+        ),
         // e(g^{b - z}, opening_1)
-        let q2 = E::miller_loop(&[(
+        (
             &sub!(v_srs.g_beta, &mul!(v_srs.g, kzg_challenge.clone()))
-                .into_affine()
-                .prepare(),
-            &vkey_opening.1.prepare(),
-        )])
+                .into_affine(),
+            &vkey_opening.1,
+        )],&E::Fqk::one())
     };
-
-    // this pair should be one when multiplied
-    let (l, r) = rayon::join(|| mul!(q1, &q2), || mul!(p1, &p2));
-    PairingCheck::from_miller_one(mul!(l, &r))
+    let mut final_check = check1;
+    final_check.merge(&check2);
+    final_check
 }
 
 /// Similar to verify_kzg_opening_g2 but for g1.
@@ -556,44 +551,41 @@ pub fn verify_kzg_opening_g1<E: Engine>(
         // first check on w1
         // let K = g^{a^{n+1}}
         // e(w1 K^{-f_w(z)},h)
-        let p1 = E::miller_loop(&[(
+        let check1 = PairingCheck::<E>::from_miller_inputs(&[(
             &sub!(
                 final_wkey.0.into_projective(),
                 &mul!(v_srs.g_alpha_n1, wkey_poly_eval)
             )
-            .into_affine()
-            .prepare(),
-            &nh.into_affine().prepare(),
-        )]),
+            .into_affine(),
+            &nh.into_affine(),
+        ),
         // e(opening, h^{a - z})
-        let p2 = E::miller_loop(&[(
-            &wkey_opening.0.prepare(),
+        (
+            &wkey_opening.0,
             &sub!(v_srs.h_alpha, &mul!(v_srs.h, *kzg_challenge))
-                .into_affine()
-                .prepare(),
-        )]),
+                .into_affine(),
+        )],&E::Fqk::one()),
         // then do second check
         // let K = g^{b^{n+1}}
         // e(w2 K^{-f_w(z)},h)
-        let q1 = E::miller_loop(&[(
+        let check2 = PairingCheck::<E>::from_miller_inputs(&[(
             &sub!(
                 final_wkey.1.into_projective(),
                 &mul!(v_srs.g_beta_n1, wkey_poly_eval)
             )
-            .into_affine()
-            .prepare(),
-            &nh.into_affine().prepare(),
-        )]),
+            .into_affine() ,
+            &nh.into_affine(),
+        ),
         // e(opening, h^{b - z})
-        let q2 = E::miller_loop(&[(
-            &wkey_opening.1.prepare(),
+        (
+            &wkey_opening.1,
             &sub!(v_srs.h_beta, &mul!(v_srs.h, *kzg_challenge))
-                .into_affine()
-                .prepare(),
-        )])
+                .into_affine(),
+        )],&E::Fqk::one())
     };
-    let (l, r) = rayon::join(|| mul!(q1, &q2), || mul!(p1, &p2));
-    PairingCheck::from_miller_one(mul!(l, &r))
+    let mut final_check = check1;
+    final_check.merge(&check2);
+    final_check
 }
 
 /// Keeps track of the variables that have been sent by the prover and must

--- a/tests/groth16_aggregation.rs
+++ b/tests/groth16_aggregation.rs
@@ -495,6 +495,7 @@ fn test_groth16_aggregation() {
         aggregate_proofs::<Bls12>(&pk, &proofs).expect("failed to aggregate proofs");
     let result = verify_aggregate_proof(&vk, &pvk, &mut rng, &statements, &aggregate_proof)
         .expect("these proofs should have been valid");
+    println!("results {:?}", result);
     assert!(result);
 
     // 2. Non power of two


### PR DESCRIPTION
Originally bases we shifted by one element
In the paper we wrote them as not-shifted as this is basically the same while it allows us to push for more aggregated proofs len.
This PR brings the paper and the implementation in synchrony.
