### PR TITLE
IPP - Bring implementation in sync with paper 

### DIFF
--- a/src/groth16/aggregate/commit.rs
+++ b/src/groth16/aggregate/commit.rs
@@ -159,15 +159,17 @@ pub fn pair<E: Engine>(
     let ((mut t1, t2), (mut u1, u2)) = rayon::join(
         || {
             rayon::join(
-                // (A * v)
+                // (A * v1)
                 || inner_product::pairing::<E>(a, &vkey.a),
-                // (w * B)
+                // (w1 * B)
                 || inner_product::pairing::<E>(&wkey.a, b),
             )
         },
         || {
             rayon::join(
+                // (A * v2)
                 || inner_product::pairing::<E>(a, &vkey.b),
+                // (w2 * B)
                 || inner_product::pairing::<E>(&wkey.b, b),
             )
         },

--- a/src/groth16/aggregate/macros.rs
+++ b/src/groth16/aggregate/macros.rs
@@ -4,11 +4,12 @@
 /// each hash input.
 macro_rules! oracle {
     // https://fromherotozero.dev/blog/introduction-to-rust-macros/
-    ( $( $x:expr), * ) => { {
+    ( $y:expr, $( $x:expr), * ) => { {
         let mut counter_nonce: usize = 0;
         let r = loop {
             counter_nonce += 1;
             let mut hash_input = Vec::new();
+            hash_input.append(&mut $y.as_bytes().to_vec());
             hash_input.extend_from_slice(&counter_nonce.to_be_bytes()[..]);
             $(
                 bincode::serialize_into(&mut hash_input, $x).expect("vec");

--- a/src/groth16/aggregate/prove.rs
+++ b/src/groth16/aggregate/prove.rs
@@ -47,7 +47,13 @@ pub fn aggregate_proofs<E: Engine + std::fmt::Debug>(
     };
 
     // Random linear combination of proofs
-    let r = oracle!(&com_ab.0, &com_ab.1, &com_c.0, &com_c.1);
+    let r = oracle!(
+        "randomr".to_string(),
+        &com_ab.0,
+        &com_ab.1,
+        &com_c.0,
+        &com_c.1
+    );
     // r, r^2, r^3, r^4 ...
     let r_vec = structured_scalar_power(proofs.len(), &r);
     // r^-1, r^-2, r^-3
@@ -121,6 +127,7 @@ fn prove_tipp_mipp<E: Engine>(
 
     // KZG challenge point
     let z = oracle!(
+        "randomz".to_string(),
         &challenges[0],
         &proof.final_vkey.0,
         &proof.final_vkey.1,
@@ -230,6 +237,7 @@ fn gipa_tipp_mipp<E: Engine>(
 
         // combine both TIPP and MIPP transcript
         let c_inv = oracle!(
+            "randomgipa".to_string(),
             &transcript,
             &tab_l.0,
             &tab_l.1,

--- a/src/groth16/aggregate/srs.rs
+++ b/src/groth16/aggregate/srs.rs
@@ -40,16 +40,17 @@ pub struct GenericSRS<E: Engine> {
 pub struct ProverSRS<E: Engine> {
     /// number of proofs to aggregate
     pub n: usize,
-    /// $\{g^a^i\}_{i=n+1}^{2n}$ where n is the number of proofs to be aggregated table starts at
-    /// i=n+1 since base is offset with commitment keys. Specially, during the KZG opening proof,
-    /// we need the vector of the SRS for g to start at $g^{a^{n+1}}$ because the commitment key
-    /// $w$ starts at the same power.
+    /// $\{g^a^i\}_{i=0}^{2n-1}$ where n is the number of proofs to be aggregated
+    /// We take all powers instead of only ones from n -> 2n-1 (w commitment key
+    /// is formed from these powers) since the prover will create a shifted
+    /// polynomial of degree 2n-1 when doing the KZG opening proof.
     pub g_alpha_powers_table: MultiscalarPrecompOwned<E::G1Affine>,
-    /// $\{h^a^i\}_{i=1}^{n}$
+    /// $\{h^a^i\}_{i=0}^{n-1}$ - here we don't need to go to 2n-1 since v
+    /// commitment key only goes up to n-1 exponent.
     pub h_alpha_powers_table: MultiscalarPrecompOwned<E::G2Affine>,
-    /// $\{g^b^i\}_{i=n+1}^{2n}$
+    /// $\{g^b^i\}_{i=0}^{2n-1}$
     pub g_beta_powers_table: MultiscalarPrecompOwned<E::G1Affine>,
-    /// $\{h^b^i\}_{i=1}^{n}$
+    /// $\{h^b^i\}_{i=0}^{n-1}$
     pub h_beta_powers_table: MultiscalarPrecompOwned<E::G2Affine>,
     /// commitment key using in MIPP and TIPP
     pub vkey: VKey<E>,
@@ -69,10 +70,6 @@ pub struct VerifierSRS<E: Engine> {
     pub g_beta: E::G1,
     pub h_alpha: E::G2,
     pub h_beta: E::G2,
-    /// equals to $g^{alpha^{n}}$
-    pub g_alpha_n1: E::G1,
-    /// equals to $g^{beta^{n}}$
-    pub g_beta_n1: E::G1,
 }
 
 impl<E: Engine> PartialEq for GenericSRS<E> {
@@ -92,8 +89,6 @@ impl<E: Engine> PartialEq for VerifierSRS<E> {
             && self.g_beta == other.g_beta
             && self.h_alpha == other.h_alpha
             && self.h_beta == other.h_beta
-            && self.g_alpha_n1 == other.g_alpha_n1
-            && self.g_beta_n1 == other.g_beta_n1
     }
 }
 
@@ -120,9 +115,10 @@ impl<E: Engine> GenericSRS<E> {
         assert!(self.g_beta_powers.len() >= tn);
         assert!(self.h_beta_powers.len() >= tn);
         let n = num_proofs;
-        // g^n -> g^{n-1}
-        let g_low = n;
-        let g_up = g_low + n;
+        // when doing the KZG opening we need _all_ coefficients from 0
+        // to 2n-1 because the polynomial is of degree 2n-1.
+        let g_low = 0;
+        let g_up = tn;
         let h_low = 0;
         let h_up = h_low + n;
         let g_alpha_powers_table =
@@ -137,12 +133,10 @@ impl<E: Engine> GenericSRS<E> {
         let v2 = self.h_beta_powers[h_low..h_up].to_vec();
         let vkey = VKey::<E> { a: v1, b: v2 };
         assert!(vkey.has_correct_len(n));
-        let w1 = self.g_alpha_powers[g_low..g_up].to_vec();
-        let w2 = self.g_beta_powers[g_low..g_up].to_vec();
-        // needed by the verifier to check KZG opening with a shifted base point for
-        // the w commitment
-        let g_alpha_n1 = w1[0].into_projective();
-        let g_beta_n1 = w2[0].into_projective();
+        // however, here we only need the "right" shifted bases for the
+        // commitment scheme.
+        let w1 = self.g_alpha_powers[n..g_up].to_vec();
+        let w2 = self.g_beta_powers[n..g_up].to_vec();
         let wkey = WKey::<E> { a: w1, b: w2 };
         assert!(wkey.has_correct_len(n));
         let pk = ProverSRS::<E> {
@@ -162,8 +156,6 @@ impl<E: Engine> GenericSRS<E> {
             g_beta: self.g_beta_powers[1].into_projective(),
             h_alpha: self.h_alpha_powers[1].into_projective(),
             h_beta: self.h_beta_powers[1].into_projective(),
-            g_alpha_n1,
-            g_beta_n1,
         };
         (pk, vk)
     }

--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -33,6 +33,7 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug, R: rand::RngCore + Se
 
     // Random linear combination of proofs
     let r = oracle!(
+        "randomr".to_string(),
         &proof.com_ab.0,
         &proof.com_ab.1,
         &proof.com_c.0,
@@ -193,6 +194,7 @@ fn verify_tipp_mipp<E: Engine, R: rand::RngCore + Send>(
     let fwkey = proof.tmipp.gipa.final_wkey;
     // KZG challenge point
     let c = oracle!(
+        "randomz".to_string(),
         &challenges.first().unwrap(),
         &fvkey.0,
         &fvkey.1,
@@ -315,6 +317,7 @@ fn gipa_verify_tipp_mipp<E: Engine>(
         // Fiat-Shamir challenge
         let transcript = challenges.last().unwrap_or(&default_transcript);
         let c_inv = oracle!(
+            "randomgipa".to_string(),
             &transcript,
             &tab_l.0,
             &tab_l.1,

--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -476,7 +476,7 @@ pub fn verify_kzg_opening_g2<E: Engine, R: rand::RngCore + Send>(
             // uH - f_v(z)H = (u - f_v)H --> v1h^{-af_v(z)}
             &sub!(
                 final_vkey.0.into_projective(),
-                &mul!(v_srs.h_alpha, vpoly_eval_z)
+                &mul!(v_srs.h, vpoly_eval_z)
             )
             .into_affine(),
         ),
@@ -495,7 +495,7 @@ pub fn verify_kzg_opening_g2<E: Engine, R: rand::RngCore + Send>(
             // uH - f_v(z)H = (u - f_v)H --> v1h^{-f_v(z)}
             &sub!(
                 final_vkey.1.into_projective(),
-                &mul!(v_srs.h_beta, vpoly_eval_z)
+                &mul!(v_srs.h, vpoly_eval_z)
             )
             .into_affine(),
         ),
@@ -529,7 +529,7 @@ pub fn verify_kzg_opening_g1<E: Engine, R: rand::RngCore + Send>(
 
     par! {
         // first check on w1
-        // let K = g^{a^{n+1}}
+        // let K = g^{a^{n}}
         // e(w1 K^{-f_w(z)},h)
         let _check1 = pairing_checks.merge_miller_inputs(&[(
             &sub!(
@@ -546,7 +546,7 @@ pub fn verify_kzg_opening_g1<E: Engine, R: rand::RngCore + Send>(
                 .into_affine(),
         )], &E::Fqk::one()),
         // then do second check
-        // let K = g^{b^{n+1}}
+        // let K = g^{b^{n}}
         // e(w2 K^{-f_w(z)},h)
         let _check2 = pairing_checks.merge_miller_inputs(&[(
             &sub!(


### PR DESCRIPTION
This PR brings the paper and the implementation in synchrony.
* When we first devised the protocol we started with the bases of the commitment keys shifted: `g^a` and `h^a^{n+1}` (and same with exponent `b`).However, we later realized we could move the bases to `g` and `h^a^n`, so we wrote it in this way in the paper. This change allows us to use the maximum aggregated proofs len (2^20 vs 2^19) when using the trusted setup from Filecoin and Zcash.
* This PR use domain separated hash functions in the respective places
* This PR changes the commitment polynomial so we use the KZG as a black box, using bases g and h directly. 

