### PR TITLE
test: don't run groth tests on GPU

### DIFF
--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! [Groth16]: https://eprint.iacr.org/2016/260
 
-#[cfg(test)]
+// The `DummyEngine` currently only works on the CPU as G1/G2 is using `Fr` and `Fr` isn't
+// supported by the GPU kernels
+#[cfg(all(test, not(feature = "gpu")))]
 mod tests;
 
 mod ext;


### PR DESCRIPTION
The `DummyEngine` doesn't work on GPUs. It is using `Fr` for G1/G2, but the
GPU kernels don't support `Fr` calculations. Hence make sure that the
tests using the `DummyEngine` are not run when the `gpu` feature is enabled.

Closes #160.

This might not be the fix we want to do, but as I already have the code, I make a PR out of it :)