### PR TITLE
refactor: replace macro call with function call

### DIFF
--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -82,18 +82,17 @@ where
             global_work_size as usize,
             Some(local_work_size as usize),
         );
-        call_kernel!(
-            kernel,
-            src_buffer,
-            dst_buffer,
-            &self.pq_buffer,
-            &self.omegas_buffer,
-            opencl::LocalBuffer::<E::Fr>::new(1 << deg),
-            n,
-            log_p,
-            deg,
-            max_deg
-        )?;
+        kernel
+            .arg(src_buffer)
+            .arg(dst_buffer)
+            .arg(&self.pq_buffer)
+            .arg(&self.omegas_buffer)
+            .arg(opencl::LocalBuffer::<E::Fr>::new(1 << deg))
+            .arg(n)
+            .arg(log_p)
+            .arg(deg)
+            .arg(max_deg)
+            .run()?;
         Ok(())
     }
 

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -174,17 +174,16 @@ where
             None,
         );
 
-        call_kernel!(
-            kernel,
-            &base_buffer,
-            &bucket_buffer,
-            &result_buffer,
-            &exp_buffer,
-            n as u32,
-            num_groups as u32,
-            num_windows as u32,
-            window_size as u32
-        )?;
+        kernel
+            .arg(&base_buffer)
+            .arg(&bucket_buffer)
+            .arg(&result_buffer)
+            .arg(&exp_buffer)
+            .arg(n as u32)
+            .arg(num_groups as u32)
+            .arg(num_windows as u32)
+            .arg(window_size as u32)
+            .run()?;
 
         let mut results = vec![<G as CurveAffine>::Projective::zero(); num_groups * num_windows];
         result_buffer.read_into(0, &mut results)?;


### PR DESCRIPTION
Macros are often used to reduce the boilerplate code to write. In case
of the kernel call the actual code isn't that much different from the
macro call.

A reader of the source code might suspect something complex going on in
the macro, although it's really straight forward. Hence I decided to
just replace the macro call with the actual code.

This also eases future uses of the call as type errors won't be hidden
within a macro, but will just be regular errors.