### PR TITLE
Fix ipp random oracle calls

### DIFF
--- a/src/groth16/aggregate/macros.rs
+++ b/src/groth16/aggregate/macros.rs
@@ -1,31 +1,11 @@
-/// returns an Fr element derived from sha256 hash of all elements that gets
-/// passed to the macro. It runs in a loop in case the Fr element doesn't have
-/// an inverse and prepends a monotically increasing counter before
-/// each hash input.
-macro_rules! oracle {
+macro_rules! tov {
     // https://fromherotozero.dev/blog/introduction-to-rust-macros/
-    ( $y:expr, $( $x:expr), * ) => { {
-        let mut counter_nonce: usize = 0;
-        let one = E::Fr::one();
-        let r = loop {
-            counter_nonce += 1;
+    ( $( $x:expr), * ) => {{
             let mut hash_input = Vec::new();
-            hash_input.append(&mut $y.as_bytes().to_vec());
-            hash_input.extend_from_slice(&counter_nonce.to_be_bytes()[..]);
             $(
                 bincode::serialize_into(&mut hash_input, $x).expect("vec");
             )*
-            let d = &Sha256::digest(&hash_input);
-            if let Some(c) = E::Fr::from_random_bytes(&d) {
-                if c == one {
-                    continue;
-                }
-                if let Some(_) = c.inverse() {
-                    break c;
-                }
-            }
-        };
-        r
+            hash_input
     }};
 }
 

--- a/src/groth16/aggregate/mod.rs
+++ b/src/groth16/aggregate/mod.rs
@@ -13,6 +13,7 @@ mod poly;
 mod proof;
 mod prove;
 mod srs;
+mod transcript;
 mod verify;
 
 pub use self::commit::*;

--- a/src/groth16/aggregate/prove.rs
+++ b/src/groth16/aggregate/prove.rs
@@ -58,13 +58,8 @@ pub fn aggregate_proofs<E: Engine + std::fmt::Debug>(
     let mut transcript = Transcript::new("snarkpack");
     transcript.domain_sep("random-r");
     transcript.append(&tov!(&com_ab.0, &com_ab.1, &com_c.0, &com_c.1));
-
-    let i: E::Fr = transcript.derive_challenge();
-    println!("\t --> after commitments {:?}", i,);
-
     transcript.append(&tov!(&public_inputs.iter().flatten().collect::<Vec<_>>()));
     let r: E::Fr = transcript.derive_challenge();
-    println!("PROVER CHALLENGE R {:?}", r);
 
     // 1,r, r^2, r^3, r^4 ...
     let r_vec = structured_scalar_power(proofs.len(), &r);
@@ -146,7 +141,6 @@ fn prove_tipp_mipp<E: Engine>(
     );
     transcript.append(&input);
     let z: E::Fr = transcript.derive_challenge();
-    println!("PROVER CHALLENGER Z {:?}", z);
 
     // Complete KZG proofs
     par! {
@@ -202,6 +196,8 @@ fn gipa_tipp_mipp<E: Engine>(
     let mut challenges_inv: Vec<E::Fr> = Vec::new();
 
     transcript.domain_sep("gipa");
+    let i: E::Fr = transcript.derive_challenge();
+
     while m_a.len() > 1 {
         // recursive step
         // Recurse with problem of half size
@@ -250,12 +246,11 @@ fn gipa_tipp_mipp<E: Engine>(
         // Fiat-Shamir challenge
         // combine both TIPP and MIPP transcript
         let input = tov!(
-            &zab_l, &zab_r, &zab_r, &zc_l, &zc_r, &tab_l.0, &tab_l.1, &tab_r.0, &tab_r.1, &tuc_l.0,
+            &zab_l, &zab_r, &zc_l, &zc_r, &tab_l.0, &tab_l.1, &tab_r.0, &tab_r.1, &tuc_l.0,
             &tuc_l.1, &tuc_r.0, &tuc_r.1
         );
         transcript.append(&input);
         let c_inv: E::Fr = transcript.derive_challenge();
-        println!("PROVER CHALLENGE GIPA {:?}", c_inv);
 
         // Optimization for multiexponentiation to rescale G2 elements with
         // 128-bit challenge Swap 'c' and 'c_inv' since can't control bit size

--- a/src/groth16/aggregate/transcript.rs
+++ b/src/groth16/aggregate/transcript.rs
@@ -68,5 +68,11 @@ mod test {
         t.domain_sep("testing domain2");
         let c2: Fr = t.derive_challenge();
         assert!(c1 != c2);
+
+        let mut t2 = Transcript::new("test");
+        t2.domain_sep("testing domain1");
+        t2.append(&input);
+        let c12 = t2.derive_challenge();
+        assert_eq!(c1, c12);
     }
 }

--- a/src/groth16/aggregate/transcript.rs
+++ b/src/groth16/aggregate/transcript.rs
@@ -3,75 +3,6 @@ use ff::{Field, PrimeField, PrimeFieldRepr};
 use groupy::CurveAffine;
 use sha2::{Digest, Sha256};
 
-pub(crate) trait Writable {
-    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()>;
-}
-
-// LEADS TO :
-// the trait ` groth16::aggregate::transcript::Writable` is not implemented for
-// `&<E as paired::Engin e>::Fqk` while E::Fqk IS a Fq12
-// -
-// - Fqk implements the Compress trait. Unfortunately it is not possible to use
-// because that would lead to a conflict in trait resolution: G1Affine might
-// implement Compress as wellas all the other type, so it wont be able to know
-// which one. Unfortunately Fqk is not extended by Compress trait
-/*impl<E, T> Writable for T*/
-//where
-//E: Engine<Fqk = T>,
-//T: Compress,
-//{
-//fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
-//// TODO: anyway to write a non compressed version without using serde?
-//self.write_compressed(out)
-//}
-/*}*/
-
-impl Writable for Fq12 {
-    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
-        // TODO: anyway to write a non compressed version without using serde?
-        self.write_compressed(out)
-    }
-}
-impl Writable for &Fq12 {
-    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
-        // TODO: anyway to write a non compressed version without using serde?
-        self.write_compressed(out)
-    }
-}
-impl Writable for Fr {
-    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
-        self.into_repr().write_be(out)
-    }
-}
-impl Writable for &Fr {
-    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
-        self.into_repr().write_be(out)
-    }
-}
-/// NOTE: I wish doing `impl<T: CurveAffine>` were possible but it raise
-/// conflicting implementation error since an external type might implement
-/// CurveAffine for Fr as well.
-impl Writable for G1Affine {
-    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
-        out.write_all(self.into_compressed().as_ref())
-    }
-}
-impl Writable for &G1Affine {
-    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
-        out.write_all(self.into_compressed().as_ref())
-    }
-}
-impl Writable for G2Affine {
-    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
-        out.write_all(self.into_compressed().as_ref())
-    }
-}
-impl Writable for &G2Affine {
-    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
-        out.write_all(self.into_compressed().as_ref())
-    }
-}
-
 pub(crate) struct Transcript {
     internal: Sha256,
 }
@@ -83,24 +14,8 @@ impl Transcript {
         Transcript { internal }
     }
 
-    pub fn append<C: Writable>(&mut self, e: &C) -> std::io::Result<()> {
-        let mut buff = Vec::new();
-        e.write_to(&mut buff)?;
-        //e.write_compressed(&mut buff)?;
+    pub fn append(&mut self, buff: &[u8]) {
         self.internal.update(&buff);
-        Ok(())
-    }
-    pub fn append_vec<'a, I, W: 'a>(&mut self, v: I) -> std::io::Result<()>
-    where
-        I: IntoIterator<Item = &'a W>,
-        W: Writable,
-    {
-        let mut buff = Vec::new();
-        for e in v {
-            e.write_to(&mut buff)?;
-        }
-        self.internal.update(&buff);
-        Ok(())
     }
     pub fn domain_sep(&mut self, tag: &str) {
         self.internal.update(tag);
@@ -145,14 +60,11 @@ mod test {
         )]))
         .expect("pairing failed");
         t.domain_sep("testing domain1");
-        t.append(&g1).expect("this should have worked");
-        t.append(&g2).expect("this should have worked");
-        t.append(&gt).expect("woups");
-        t.append(&Fr::one()).expect("this should have worked");
-        t.append_vec(&[&g1, &g1, &g1]).expect("woups");
-        t.append_vec(&[&g2, &g2, &g2]).expect("woups");
-        t.append_vec(&[&gt, &gt, &gt]).expect("woups");
+        let input = tov!(&g1, &g2, &gt, &Fr::one());
+        t.append(&input);
         let c1: Fr = t.derive_challenge();
+        let c11: Fr = t.derive_challenge();
+        assert_eq!(c1, c11);
         t.domain_sep("testing domain2");
         let c2: Fr = t.derive_challenge();
         assert!(c1 != c2);

--- a/src/groth16/aggregate/transcript.rs
+++ b/src/groth16/aggregate/transcript.rs
@@ -1,0 +1,160 @@
+use crate::bls::{Compress, Engine, Fq12, Fr, G1Affine, G2Affine};
+use ff::{Field, PrimeField, PrimeFieldRepr};
+use groupy::CurveAffine;
+use sha2::{Digest, Sha256};
+
+pub(crate) trait Writable {
+    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()>;
+}
+
+// LEADS TO :
+// the trait ` groth16::aggregate::transcript::Writable` is not implemented for
+// `&<E as paired::Engin e>::Fqk` while E::Fqk IS a Fq12
+// -
+// - Fqk implements the Compress trait. Unfortunately it is not possible to use
+// because that would lead to a conflict in trait resolution: G1Affine might
+// implement Compress as wellas all the other type, so it wont be able to know
+// which one. Unfortunately Fqk is not extended by Compress trait
+/*impl<E, T> Writable for T*/
+//where
+//E: Engine<Fqk = T>,
+//T: Compress,
+//{
+//fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
+//// TODO: anyway to write a non compressed version without using serde?
+//self.write_compressed(out)
+//}
+/*}*/
+
+impl Writable for Fq12 {
+    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
+        // TODO: anyway to write a non compressed version without using serde?
+        self.write_compressed(out)
+    }
+}
+impl Writable for &Fq12 {
+    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
+        // TODO: anyway to write a non compressed version without using serde?
+        self.write_compressed(out)
+    }
+}
+impl Writable for Fr {
+    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
+        self.into_repr().write_be(out)
+    }
+}
+impl Writable for &Fr {
+    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
+        self.into_repr().write_be(out)
+    }
+}
+/// NOTE: I wish doing `impl<T: CurveAffine>` were possible but it raise
+/// conflicting implementation error since an external type might implement
+/// CurveAffine for Fr as well.
+impl Writable for G1Affine {
+    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
+        out.write_all(self.into_compressed().as_ref())
+    }
+}
+impl Writable for &G1Affine {
+    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
+        out.write_all(self.into_compressed().as_ref())
+    }
+}
+impl Writable for G2Affine {
+    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
+        out.write_all(self.into_compressed().as_ref())
+    }
+}
+impl Writable for &G2Affine {
+    fn write_to<W: std::io::Write>(&self, out: &mut W) -> std::io::Result<()> {
+        out.write_all(self.into_compressed().as_ref())
+    }
+}
+
+pub(crate) struct Transcript {
+    internal: Sha256,
+}
+
+impl Transcript {
+    pub fn new(application_tag: &str) -> Self {
+        let mut internal = sha2::Sha256::new();
+        internal.update(application_tag);
+        Transcript { internal }
+    }
+
+    pub fn append<C: Writable>(&mut self, e: &C) -> std::io::Result<()> {
+        let mut buff = Vec::new();
+        e.write_to(&mut buff)?;
+        //e.write_compressed(&mut buff)?;
+        self.internal.update(&buff);
+        Ok(())
+    }
+    pub fn append_vec<'a, I, W: 'a>(&mut self, v: I) -> std::io::Result<()>
+    where
+        I: IntoIterator<Item = &'a W>,
+        W: Writable,
+    {
+        let mut buff = Vec::new();
+        for e in v {
+            e.write_to(&mut buff)?;
+        }
+        self.internal.update(&buff);
+        Ok(())
+    }
+    pub fn domain_sep(&mut self, tag: &str) {
+        self.internal.update(tag);
+    }
+    pub fn derive_challenge<F: PrimeField>(&self) -> F {
+        let mut state = self.internal.clone();
+        let mut counter_nonce: usize = 0;
+        let one = F::one();
+        let r = loop {
+            counter_nonce += 1;
+            state.update(&counter_nonce.to_be_bytes()[..]);
+            let curr_state = state.clone();
+            let digest = curr_state.finalize();
+            if let Some(c) = F::from_random_bytes(&digest) {
+                if c == one {
+                    continue;
+                }
+                if let Some(_) = c.inverse() {
+                    break c;
+                }
+            }
+        };
+        r
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::bls::{Bls12, Fr, G1Affine};
+    use crate::bls::{Engine, PairingCurveAffine};
+    use ff::Field;
+
+    #[test]
+    fn test_transcript() {
+        let mut t = Transcript::new("test");
+        let g1 = G1Affine::one();
+        let g2 = G2Affine::one();
+        let gt = <Bls12 as Engine>::final_exponentiation(&<Bls12 as Engine>::miller_loop(&[(
+            &g1.prepare(),
+            &g2.prepare(),
+        )]))
+        .expect("pairing failed");
+        t.domain_sep("testing domain1");
+        t.append(&g1).expect("this should have worked");
+        t.append(&g2).expect("this should have worked");
+        t.append(&gt).expect("woups");
+        t.append(&Fr::one()).expect("this should have worked");
+        t.append_vec(&[&g1, &g1, &g1]).expect("woups");
+        t.append_vec(&[&g2, &g2, &g2]).expect("woups");
+        t.append_vec(&[&gt, &gt, &gt]).expect("woups");
+        let c1: Fr = t.derive_challenge();
+        t.domain_sep("testing domain2");
+        let c2: Fr = t.derive_challenge();
+        assert!(c1 != c2);
+    }
+}

--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -50,6 +50,8 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug, R: rand::RngCore + Se
     transcript.append(&tov!(&public_inputs.iter().flatten().collect::<Vec<_>>()));
     let r: E::Fr = transcript.derive_challenge();
 
+    transcript.append(&tov!(&proof.ip_ab, &proof.agg_c));
+
     let pairing_checks = PairingChecks::new(rng);
     let pairing_checks_copy = &pairing_checks;
 

--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -38,7 +38,7 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug, R: rand::RngCore + Se
     }
 
     // Random linear combination of proofs
-    let mut transcript = Transcript::new("snarpack");
+    let mut transcript = Transcript::new("snarkpack");
     transcript.domain_sep("random-r");
     transcript.append(&tov!(
         &proof.com_ab.0,
@@ -47,12 +47,8 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug, R: rand::RngCore + Se
         &proof.com_c.1
     ));
 
-    let i: E::Fr = transcript.derive_challenge();
-    println!("\t --> after commitments {:?}", i,);
-
     transcript.append(&tov!(&public_inputs.iter().flatten().collect::<Vec<_>>()));
     let r: E::Fr = transcript.derive_challenge();
-    println!("VERIFIER CHALLENGE R {:?}", r);
 
     let pairing_checks = PairingChecks::new(rng);
     let pairing_checks_copy = &pairing_checks;
@@ -212,7 +208,6 @@ fn verify_tipp_mipp<E: Engine, R: rand::RngCore + Send>(
     );
     transcript.append(&input);
     let c: E::Fr = transcript.derive_challenge();
-    println!("VERIFIER CHALLENGE Z {:?}", c);
 
     // we take reference so they are able to be copied in the par! macro
     let final_a = &proof.tmipp.gipa.final_a;
@@ -317,6 +312,7 @@ fn gipa_verify_tipp_mipp<E: Engine>(
     let mut challenges_inv = Vec::new();
 
     transcript.domain_sep("gipa");
+
     // We first generate all challenges as this is the only consecutive process
     // that can not be parallelized then we scale the commitments in a
     // parallelized way
@@ -336,7 +332,6 @@ fn gipa_verify_tipp_mipp<E: Engine>(
         );
         transcript.append(&input);
         let c_inv: E::Fr = transcript.derive_challenge();
-        println!("VERIFIER CHALLENGE GIPA {:?}", c_inv);
         let c = c_inv.inverse().unwrap();
         challenges.push(c);
         challenges_inv.push(c_inv);

--- a/tests/groth16_aggregation.rs
+++ b/tests/groth16_aggregation.rs
@@ -309,8 +309,8 @@ fn test_groth16_bench() {
             // Aggregate proofs using inner product proofs
             let start = Instant::now();
             println!("\t-Aggregation...");
-            let aggregate_proof =
-                aggregate_proofs::<Bls12>(&pk, &proofs[..i]).expect("failed to aggregate proofs");
+            let aggregate_proof = aggregate_proofs::<Bls12>(&pk, &statements[..i], &proofs[..i])
+                .expect("failed to aggregate proofs");
             let prover_time = start.elapsed().as_millis();
             println!("\t-Aggregate Verification ...");
 
@@ -493,13 +493,13 @@ fn test_groth16_aggregation() {
     // 1. Valid proofs
     println!("Aggregating {} Groth16 proofs...", proofs.len());
     let mut aggregate_proof =
-        aggregate_proofs::<Bls12>(&pk, &proofs).expect("failed to aggregate proofs");
+        aggregate_proofs::<Bls12>(&pk, &statements, &proofs).expect("failed to aggregate proofs");
     let result = verify_aggregate_proof(&vk, &pvk, &mut rng, &statements, &aggregate_proof)
         .expect("these proofs should have been valid");
     assert!(result);
 
     // 2. Non power of two
-    let err = aggregate_proofs::<Bls12>(&pk, &proofs[0..NUM_PROOFS - 1]).unwrap_err();
+    let err = aggregate_proofs::<Bls12>(&pk, &statements, &proofs[0..NUM_PROOFS - 1]).unwrap_err();
     assert!(match err {
         SynthesisError::NonPowerOfTwo => true,
         _ => false,
@@ -508,8 +508,8 @@ fn test_groth16_aggregation() {
     // 3. aggregate invalid proof content (random A, B, and C)
     let old_a = proofs[0].a.clone();
     proofs[0].a = <Bls12 as Engine>::G1::random(&mut rng).into_affine();
-    let invalid_agg =
-        aggregate_proofs::<Bls12>(&pk, &proofs).expect("I should be able to aggregate");
+    let invalid_agg = aggregate_proofs::<Bls12>(&pk, &statements, &proofs)
+        .expect("I should be able to aggregate");
     let res = verify_aggregate_proof(&vk, &pvk, &mut rng, &statements, &invalid_agg)
         .expect("no synthesis");
     assert!(res == false);
@@ -517,8 +517,8 @@ fn test_groth16_aggregation() {
 
     let old_b = proofs[0].b.clone();
     proofs[0].b = <Bls12 as Engine>::G2::random(&mut rng).into_affine();
-    let invalid_agg =
-        aggregate_proofs::<Bls12>(&pk, &proofs).expect("I should be able to aggregate");
+    let invalid_agg = aggregate_proofs::<Bls12>(&pk, &statements, &proofs)
+        .expect("I should be able to aggregate");
     let res = verify_aggregate_proof(&vk, &pvk, &mut rng, &statements, &invalid_agg)
         .expect("no synthesis");
     assert!(res == false);
@@ -526,8 +526,8 @@ fn test_groth16_aggregation() {
 
     let old_c = proofs[0].c.clone();
     proofs[0].c = <Bls12 as Engine>::G1::random(&mut rng).into_affine();
-    let invalid_agg =
-        aggregate_proofs::<Bls12>(&pk, &proofs).expect("I should be able to aggregate");
+    let invalid_agg = aggregate_proofs::<Bls12>(&pk, &statements, &proofs)
+        .expect("I should be able to aggregate");
     let res = verify_aggregate_proof(&vk, &pvk, &mut rng, &statements, &invalid_agg)
         .expect("no synthesis");
     assert!(res == false);
@@ -622,7 +622,7 @@ fn test_groth16_aggregation_mimc() {
     let start = Instant::now();
     println!("Aggregating {} Groth16 proofs...", NUM_PROOFS_TO_AGGREGATE);
     let aggregate_proof =
-        aggregate_proofs::<Bls12>(&pk, &proofs).expect("failed to aggregate proofs");
+        aggregate_proofs::<Bls12>(&pk, &images, &proofs).expect("failed to aggregate proofs");
     let prover_time = start.elapsed().as_millis();
 
     println!("Verifying aggregated proof...");


### PR DESCRIPTION
This PR brings the notion of transcript to the aggregation proof system by systematically hashing prover's elements that gets sent to the verifier, with domain separation tags. Compared to previous version, this hashes the public inputs, as well as the `agg_c` and `ip_ab` elements which were not hashed before.
This PR is **API BREAKING**: indeed it requires now the public inputs to the aggregation function ( cc/ @cryptonemo  !)

**Note** I put a first [commit](https://github.com/filecoin-project/bellperson/commit/773858ce285d94bb37f4841fa3d36d6abca8d0f6) where I tried to do a nice API for the transcript such that it accepts any points / scalar etc, but I wasn't able to make it work. I believe it is due to the way traits are organized in paired: there a 3 up to different traits to serialize elements, and they're not compatible nor consistent with each other. After hours of trying out, I resolved to use `bincode` and a macro to make it "ok" from an end user point of view.