### PR TITLE
feat: use opencl3 based rust-gpu-tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ blstrs = { version = "0.3", optional = true }
 paired = { version = "0.22.0", optional = true }
 
 # gpu feature 
-rust-gpu-tools = { version = "0.3.0", optional = true }
+#rust-gpu-tools = { version = "0.3.0", optional = true }
+rust-gpu-tools = { git = "https://github.com/filecoin-project/rust-gpu-tools", rev = "2827a11196dd638c9afe5aeb99f6425c0d1a7670", optional = true }
 ff-cl-gen = { version = "0.3.0", optional = true }
 fs2 = { version = "0.4.3", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,7 @@ blstrs = { version = "0.3", optional = true }
 paired = { version = "0.22.0", optional = true }
 
 # gpu feature 
-#rust-gpu-tools = { version = "0.3.0", optional = true }
-rust-gpu-tools = { git = "https://github.com/filecoin-project/rust-gpu-tools", rev = "2827a11196dd638c9afe5aeb99f6425c0d1a7670", optional = true }
+rust-gpu-tools = { version = "0.4.0", optional = true }
 ff-cl-gen = { version = "0.3.0", optional = true }
 fs2 = { version = "0.4.3", optional = true }
 

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -37,16 +37,16 @@ where
         }
 
         // Select the first device for FFT
-        let device = devices[0].clone();
+        let device = devices[0];
 
         let src = sources::kernel::<E>(device.brand() == opencl::Brand::Nvidia);
 
-        let program = opencl::Program::from_opencl(device, &src)?;
+        let program = opencl::Program::from_opencl(&device, &src)?;
         let pq_buffer = program.create_buffer::<E::Fr>(1 << MAX_LOG2_RADIX >> 1)?;
         let omegas_buffer = program.create_buffer::<E::Fr>(LOG2_MAX_ELEMENTS)?;
 
         info!("FFT: 1 working device(s) selected.");
-        info!("FFT: Device 0: {}", program.device().name());
+        info!("FFT: Device 0: {}", device.name());
 
         Ok(FFTKernel {
             program,
@@ -81,18 +81,18 @@ where
         let kernel = self.program.create_kernel(
             "radix_fft",
             global_work_size as usize,
-            Some(local_work_size as usize),
-        );
+            local_work_size as usize,
+        )?;
         kernel
             .arg(src_buffer)
             .arg(dst_buffer)
             .arg(&self.pq_buffer)
             .arg(&self.omegas_buffer)
-            .arg(opencl::LocalBuffer::<E::Fr>::new(1 << deg))
-            .arg(n)
-            .arg(log_p)
-            .arg(deg)
-            .arg(max_deg)
+            .arg(&opencl::LocalBuffer::<E::Fr>::new(1 << deg))
+            .arg(&n)
+            .arg(&log_p)
+            .arg(&deg)
+            .arg(&max_deg)
             .run()?;
         Ok(())
     }
@@ -111,7 +111,7 @@ where
                 pq[i].mul_assign(&twiddle);
             }
         }
-        self.pq_buffer.write_from(0, &pq)?;
+        self.program.write_from_buffer(&self.pq_buffer, 0, &pq)?;
 
         // Precalculate [omega, omega^2, omega^4, omega^8, ..., omega^(2^31)]
         let mut omegas = vec![E::Fr::zero(); 32];
@@ -119,7 +119,8 @@ where
         for i in 1..LOG2_MAX_ELEMENTS {
             omegas[i] = omegas[i - 1].pow([2u64]);
         }
-        self.omegas_buffer.write_from(0, &omegas)?;
+        self.program
+            .write_from_buffer(&self.omegas_buffer, 0, &omegas)?;
 
         Ok(())
     }
@@ -135,7 +136,7 @@ where
         let max_deg = cmp::min(MAX_LOG2_RADIX, log_n);
         self.setup_pq_omegas(omega, n, max_deg)?;
 
-        src_buffer.write_from(0, &*a)?;
+        self.program.write_from_buffer(&src_buffer, 0, &*a)?;
         let mut log_p = 0u32;
         while log_p < log_n {
             let deg = cmp::min(max_deg, log_n - log_p);
@@ -144,7 +145,7 @@ where
             std::mem::swap(&mut src_buffer, &mut dst_buffer);
         }
 
-        src_buffer.read_into(0, a)?;
+        self.program.read_into_buffer(&src_buffer, 0, a)?;
 
         Ok(())
     }

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -39,7 +39,7 @@ where
         // Select the first device for FFT
         let device = devices[0];
 
-        let src = sources::kernel::<E>(device.brand() == opencl::Brand::Nvidia);
+        let src = sources::kernel::<E>(device.vendor() == opencl::Vendor::Nvidia);
 
         let program = opencl::Program::from_opencl(&device, &src)?;
         let pq_buffer = program.create_buffer::<E::Fr>(1 << MAX_LOG2_RADIX >> 1)?;
@@ -77,7 +77,7 @@ where
 
         let n = 1u32 << log_n;
         let local_work_size = 1 << cmp::min(deg - 1, MAX_LOG2_LOCAL_WORK_SIZE);
-        let global_work_size = (n >> deg) * local_work_size;
+        let global_work_size = n >> deg;
         let kernel = self.program.create_kernel(
             "radix_fft",
             global_work_size as usize,

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -101,7 +101,7 @@ where
     E: Engine,
 {
     pub fn create(d: opencl::Device, priority: bool) -> GPUResult<SingleMultiexpKernel<E>> {
-        let src = sources::kernel::<E>(d.brand() == opencl::Brand::Nvidia);
+        let src = sources::kernel::<E>(d.vendor() == opencl::Vendor::Nvidia);
 
         let exp_bits = exp_size::<E>() * 8;
         let core_count = utils::get_core_count(&d);
@@ -156,10 +156,9 @@ where
             .program
             .create_buffer::<<G as CurveAffine>::Projective>(2 * self.core_count)?;
 
-        // Make global work size divisible by `LOCAL_WORK_SIZE`
-        let mut global_work_size = num_windows * num_groups;
-        global_work_size +=
-            (LOCAL_WORK_SIZE - (global_work_size % LOCAL_WORK_SIZE)) % LOCAL_WORK_SIZE;
+        // The global work size follows CUDA's definition and is the number of `LOCAL_WORK_SIZE`
+        // sized thread groups.
+        let global_work_size = (num_windows * num_groups + LOCAL_WORK_SIZE - 1) / LOCAL_WORK_SIZE;
 
         let kernel = self.program.create_kernel(
             if TypeId::of::<G>() == TypeId::of::<E::G1Affine>() {
@@ -184,7 +183,7 @@ where
             .arg(&(window_size as u32))
             .run()?;
 
-        let mut results = vec![<G as CurveAffine>::Projective::zero(); num_groups * num_windows];
+        let mut results = vec![<G as CurveAffine>::Projective::zero(); 2 * self.core_count];
         self.program
             .read_into_buffer(&result_buffer, 0, &mut results)?;
 


### PR DESCRIPTION
Upgrade to a version of rust-gpu-tools that is using `opencl3` instead
of `ocl`.

The local work size is now explicitly set and not longer automatically
determined by the OpenCL implementation.