### PR TITLE
WIP: Minimal code to integrate the scheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ rust-gpu-tools = { version = "0.5.0", optional = true, default-features = false 
 ec-gpu = { version = "0.1.0", optional = true }
 ec-gpu-gen = { version = "0.1.0", optional = true }
 fs2 = { version = "0.4.3", optional = true }
+scheduler_client = {package = "client", git = "https://github.com/Zondax/filecoin-scheduling.git", optional = true}
 
 
 [dev-dependencies]
@@ -65,8 +66,8 @@ sha2 = "0.9"
 
 [features]
 default = ["groth16"]
-cuda = ["rust-gpu-tools/cuda", "ec-gpu", "ec-gpu-gen", "fs2", "blstrs/gpu"]
-opencl = ["rust-gpu-tools/opencl", "ec-gpu", "ec-gpu-gen", "fs2", "blstrs/gpu"]
+cuda = ["rust-gpu-tools/cuda", "ec-gpu", "ec-gpu-gen", "fs2", "blstrs/gpu","scheduler_client/cuda"]
+opencl = ["rust-gpu-tools/opencl", "ec-gpu", "ec-gpu-gen", "fs2", "blstrs/gpu", "scheduler_client/opencl"]
 groth16 = []
 
 # This feature disables/modifies long running tests to make the suitable for code coverage

--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -56,6 +56,9 @@ pub enum SynthesisError {
     IncompatibleLengthVector(String),
     #[error("invalid pairing")]
     InvalidPairing,
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
+    #[error("Scheduler error: {0}")]
+    Scheduler(#[from] scheduler_client::Error),
 }
 
 /// Represents a constraint system which can have new variables

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -1,101 +1,11 @@
-use fs2::FileExt;
-use log::{debug, info, warn};
-use std::fs::File;
-use std::path::PathBuf;
-
-const GPU_LOCK_NAME: &str = "bellman.gpu.lock";
-const PRIORITY_LOCK_NAME: &str = "bellman.priority.lock";
-fn tmp_path(filename: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(filename);
-    p
-}
-
-/// `GPULock` prevents two kernel objects to be instantiated simultaneously.
-#[allow(clippy::upper_case_acronyms)]
-#[derive(Debug)]
-pub struct GPULock(File);
-impl GPULock {
-    pub fn lock() -> GPULock {
-        let gpu_lock_file = tmp_path(GPU_LOCK_NAME);
-        debug!("Acquiring GPU lock at {:?} ...", &gpu_lock_file);
-        let f = File::create(&gpu_lock_file)
-            .unwrap_or_else(|_| panic!("Cannot create GPU lock file at {:?}", &gpu_lock_file));
-        f.lock_exclusive().unwrap();
-        debug!("GPU lock acquired!");
-        GPULock(f)
-    }
-}
-impl Drop for GPULock {
-    fn drop(&mut self) {
-        self.0.unlock().unwrap();
-        debug!("GPU lock released!");
-    }
-}
-
-/// `PrioriyLock` is like a flag. When acquired, it means a high-priority process
-/// needs to acquire the GPU really soon. Acquiring the `PriorityLock` is like
-/// signaling all other processes to release their `GPULock`s.
-/// Only one process can have the `PriorityLock` at a time.
-#[derive(Debug)]
-pub struct PriorityLock(File);
-impl PriorityLock {
-    pub fn lock() -> PriorityLock {
-        let priority_lock_file = tmp_path(PRIORITY_LOCK_NAME);
-        debug!("Acquiring priority lock at {:?} ...", &priority_lock_file);
-        let f = File::create(&priority_lock_file).unwrap_or_else(|_| {
-            panic!(
-                "Cannot create priority lock file at {:?}",
-                &priority_lock_file
-            )
-        });
-        f.lock_exclusive().unwrap();
-        debug!("Priority lock acquired!");
-        PriorityLock(f)
-    }
-
-    pub fn wait(priority: bool) {
-        if !priority {
-            if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME))
-                .unwrap()
-                .lock_exclusive()
-            {
-                warn!("failed to create priority log: {:?}", err);
-            }
-        }
-    }
-
-    pub fn should_break(priority: bool) -> bool {
-        if priority {
-            return false;
-        }
-        if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME))
-            .unwrap()
-            .try_lock_shared()
-        {
-            // Check that the error is actually a locking one
-            if err.raw_os_error() == fs2::lock_contended_error().raw_os_error() {
-                return true;
-            } else {
-                warn!("failed to check lock: {:?}", err);
-            }
-        }
-        false
-    }
-}
-
-impl Drop for PriorityLock {
-    fn drop(&mut self) {
-        self.0.unlock().unwrap();
-        debug!("Priority lock released!");
-    }
-}
-
 use super::error::{GPUError, GPUResult};
 use super::fft::FFTKernel;
 use super::multiexp::MultiexpKernel;
 use crate::domain::create_fft_kernel;
 use crate::multiexp::create_multiexp_kernel;
+use log::warn;
+
+use scheduler_client::ResourceAlloc;
 
 macro_rules! locked_kernel {
     ($class:ident, $kern:ident, $func:ident, $name:expr) => {
@@ -105,27 +15,25 @@ macro_rules! locked_kernel {
             E: pairing::Engine + crate::gpu::GpuEngine,
         {
             log_d: usize,
-            priority: bool,
             kernel: Option<$kern<E>>,
+            alloc: Option<ResourceAlloc>,
         }
 
         impl<E> $class<E>
         where
             E: pairing::Engine + crate::gpu::GpuEngine,
         {
-            pub fn new(log_d: usize, priority: bool) -> $class<E> {
+            pub fn new(log_d: usize, alloc: Option<&ResourceAlloc>) -> $class<E> {
                 $class::<E> {
                     log_d,
-                    priority,
                     kernel: None,
+                    alloc: alloc.map(|a| a.clone()),
                 }
             }
 
             fn init(&mut self) {
                 if self.kernel.is_none() {
-                    PriorityLock::wait(self.priority);
-                    info!("GPU is available for {}!", $name);
-                    self.kernel = $func::<E>(self.log_d, self.priority);
+                    self.kernel = $func::<E>(self.log_d, self.alloc.as_ref());
                 }
             }
 

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -15,8 +15,8 @@ impl<E> FFTKernel<E>
 where
     E: Engine,
 {
-    pub fn create(_: bool) -> GPUResult<FFTKernel<E>> {
-        Err(GPUError::GPUDisabled)
+    pub fn create() -> GPUResult<FFTKernel<E>> {
+        return Err(GPUError::GPUDisabled);
     }
 
     pub fn radix_fft(&mut self, _: &mut [E::Fr], _: &E::Fr, _: u32) -> GPUResult<()> {
@@ -40,8 +40,8 @@ impl<E> MultiexpKernel<E>
 where
     E: Engine,
 {
-    pub fn create(_: bool) -> GPUResult<MultiexpKernel<E>> {
-        Err(GPUError::GPUDisabled)
+    pub fn create() -> GPUResult<MultiexpKernel<E>> {
+        return Err(GPUError::GPUDisabled);
     }
 
     pub fn multiexp<G>(
@@ -70,7 +70,7 @@ macro_rules! locked_kernel {
         where
             E: Engine,
         {
-            pub fn new(_: usize, _: bool) -> $class<E> {
+            pub fn new(_: usize) -> $class<E> {
                 $class::<E>(PhantomData)
             }
 

--- a/src/groth16/ext.rs
+++ b/src/groth16/ext.rs
@@ -1,5 +1,6 @@
 use super::{create_proof_batch_priority, create_random_proof_batch_priority};
 use super::{ParameterSource, Proof};
+use crate::groth16::BellTaskType;
 use crate::{gpu, Circuit, SynthesisError};
 use pairing::MultiMillerLoop;
 use rand_core::RngCore;
@@ -15,7 +16,7 @@ where
     C: Circuit<E::Fr> + Send,
 {
     let proofs =
-        create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], false)?;
+        create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], None)?;
     Ok(proofs.into_iter().next().unwrap())
 }
 
@@ -30,7 +31,7 @@ where
     R: RngCore,
 {
     let proofs =
-        create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, false)?;
+        create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, None)?;
     Ok(proofs.into_iter().next().unwrap())
 }
 
@@ -44,7 +45,50 @@ where
     E: gpu::GpuEngine + MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
 {
-    create_proof_batch_priority::<E, C, P>(circuits, params, r, s, false)
+    create_proof_batch_priority::<E, C, P>(circuits, params, r, s, None)
+}
+
+// Winning/window and tree_builders/hashers use this library. as a general use case, we should pass to
+// the scheduler the deadlines and task types. The deadline is the priority, the sooner the task must be completed
+// the more the scheduler will prioritize it.
+// the task_type is used to get the exclusive resources that a  task can use.
+// the rest of the API in this file remains the same, the no priority functions bellow, assign None as a
+// deadline, the other functions with the in_priority suffix set the deadline to now. both keep the
+// task_type as None, indicating there are not exclusive resources for them.
+
+// this function omits the deadline but takes in a task_type, for now the deadline is hardcoded in
+// the scheduler-client library according to the task_type. the scheduler will assigned the lowest
+// possible deadline to tasks that do not have a type. this function is called by rust-fil-proof
+// and it was easier to refactor the functions there to include only one parameter than modifying
+// them to take 2(deadline plus task_type)
+pub fn create_random_proof_batch_with_type<E, C, R, P: ParameterSource<E>>(
+    circuits: Vec<C>,
+    params: P,
+    rng: &mut R,
+    task_type: Option<BellTaskType>,
+) -> Result<Vec<Proof<E>>, SynthesisError>
+where
+    E: gpu::GpuEngine + MultiMillerLoop,
+    C: Circuit<E::Fr> + Send,
+    R: RngCore,
+{
+    create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, task_type)
+}
+
+pub fn create_random_proof_with_type<E, C, R, P: ParameterSource<E>>(
+    circuit: C,
+    params: P,
+    rng: &mut R,
+    task_type: Option<BellTaskType>,
+) -> Result<Proof<E>, SynthesisError>
+where
+    E: gpu::GpuEngine + MultiMillerLoop,
+    C: Circuit<E::Fr> + Send,
+    R: RngCore,
+{
+    let proofs =
+        create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, task_type)?;
+    Ok(proofs.into_iter().next().unwrap())
 }
 
 pub fn create_random_proof_batch<E, C, R, P: ParameterSource<E>>(
@@ -57,61 +101,5 @@ where
     C: Circuit<E::Fr> + Send,
     R: RngCore,
 {
-    create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, false)
-}
-
-pub fn create_proof_in_priority<E, C, P: ParameterSource<E>>(
-    circuit: C,
-    params: P,
-    r: E::Fr,
-    s: E::Fr,
-) -> Result<Proof<E>, SynthesisError>
-where
-    E: gpu::GpuEngine + MultiMillerLoop,
-    C: Circuit<E::Fr> + Send,
-{
-    let proofs =
-        create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], true)?;
-    Ok(proofs.into_iter().next().unwrap())
-}
-
-pub fn create_random_proof_in_priority<E, C, R, P: ParameterSource<E>>(
-    circuit: C,
-    params: P,
-    rng: &mut R,
-) -> Result<Proof<E>, SynthesisError>
-where
-    E: gpu::GpuEngine + MultiMillerLoop,
-    C: Circuit<E::Fr> + Send,
-    R: RngCore,
-{
-    let proofs =
-        create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, true)?;
-    Ok(proofs.into_iter().next().unwrap())
-}
-
-pub fn create_proof_batch_in_priority<E, C, P: ParameterSource<E>>(
-    circuits: Vec<C>,
-    params: P,
-    r: Vec<E::Fr>,
-    s: Vec<E::Fr>,
-) -> Result<Vec<Proof<E>>, SynthesisError>
-where
-    E: gpu::GpuEngine + MultiMillerLoop,
-    C: Circuit<E::Fr> + Send,
-{
-    create_proof_batch_priority::<E, C, P>(circuits, params, r, s, true)
-}
-
-pub fn create_random_proof_batch_in_priority<E, C, R, P: ParameterSource<E>>(
-    circuits: Vec<C>,
-    params: P,
-    rng: &mut R,
-) -> Result<Vec<Proof<E>>, SynthesisError>
-where
-    E: gpu::GpuEngine + MultiMillerLoop,
-    C: Circuit<E::Fr> + Send,
-    R: RngCore,
-{
-    create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, true)
+    create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, None)
 }

--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -14,6 +14,7 @@ mod mapped_params;
 mod params;
 mod proof;
 mod prover;
+mod prover_ext;
 mod verifier;
 mod verifying_key;
 
@@ -25,5 +26,13 @@ pub use self::mapped_params::*;
 pub use self::params::*;
 pub use self::proof::*;
 pub use self::prover::*;
+pub(crate) use self::prover_ext::*;
 pub use self::verifier::*;
 pub use self::verifying_key::*;
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum BellTaskType {
+    WinningPost,
+    WindowPost,
+    MerkleTree,
+}

--- a/src/groth16/prover_ext.rs
+++ b/src/groth16/prover_ext.rs
@@ -1,0 +1,160 @@
+use super::BellTaskType;
+use crate::gpu;
+use pairing::Engine;
+
+use crate::gpu::{LockedFFTKernel, LockedMultiexpKernel};
+use crate::SynthesisError;
+#[cfg(any(feature = "cuda", feature = "opencl"))]
+use log::warn;
+
+#[cfg(any(feature = "cuda", feature = "opencl"))]
+use scheduler_client::{
+    list_devices, Client as SClient, Error as ClientError, ResourceAlloc, ResourceMemory,
+    ResourceReq, ResourceType, TaskFunc, TaskReqBuilder, TaskResult, TaskType,
+};
+
+#[cfg(any(feature = "cuda", feature = "opencl"))]
+const TIMEOUT: u64 = 1200;
+pub struct Client {
+    _task_type: BellTaskType,
+
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
+    inner: SClient,
+}
+
+impl Client {
+    pub fn new(_task_type: Option<BellTaskType>) -> Result<Client, SynthesisError> {
+        let _task_type = _task_type.unwrap_or(BellTaskType::MerkleTree);
+        #[cfg(any(feature = "cuda", feature = "opencl"))]
+        let inner = SClient::register::<SynthesisError>()?;
+
+        Ok(Self {
+            _task_type,
+            #[cfg(any(feature = "cuda", feature = "opencl"))]
+            inner,
+        })
+    }
+
+    pub fn update_context(&mut self, _name: String, _context: String) {
+        #[cfg(any(feature = "cuda", feature = "opencl"))]
+        self.inner.set_name(_name);
+        #[cfg(any(feature = "cuda", feature = "opencl"))]
+        self.inner.set_context(_context);
+    }
+}
+
+macro_rules! solver {
+    ($class:ident, $kern:ident) => {
+        pub struct $class<E, F, R>
+        where
+            for<'a> F: FnMut(&'a mut Option<$kern<E>>) -> Result<R, SynthesisError>,
+            E: Engine + gpu::GpuEngine,
+        {
+            kernel: Option<$kern<E>>,
+            _log_d: usize,
+            call: F,
+        }
+
+        impl<E, F, R> $class<E, F, R>
+        where
+            for<'a> F: FnMut(&'a mut Option<$kern<E>>) -> Result<R, SynthesisError>,
+            E: Engine + gpu::GpuEngine,
+        {
+            pub fn new(log_d: usize, call: F) -> Self {
+                $class::<E, F, R> {
+                    _log_d: log_d,
+                    kernel: None,
+                    call,
+                }
+            }
+
+            #[cfg(any(feature = "cuda", feature = "opencl"))]
+            pub fn solve(&mut self, client: &mut Client) -> Result<(), SynthesisError> {
+                use std::time::Duration;
+
+                let task_type = match client._task_type {
+                    BellTaskType::WinningPost => TaskType::WinningPost,
+                    BellTaskType::WindowPost => TaskType::WindowPost,
+                    _ => TaskType::MerkleTree,
+                };
+
+                let requirements = {
+                    let resouce_req = ResourceReq {
+                        resource: ResourceType::Gpu(ResourceMemory::All),
+                        quantity: list_devices().gpu_devices().len(),
+                        preemptible: true,
+                    };
+                    let task_req = TaskReqBuilder::new()
+                        .resource_req(resouce_req)
+                        .with_task_type(task_type);
+                    task_req.build()
+                };
+
+                let task_type = requirements.task_type;
+
+                let res = client
+                    .inner
+                    .schedule_one_of(self, requirements, Duration::from_secs(TIMEOUT))
+                    .map(|_| ());
+
+                match res {
+                    Ok(res) => Ok(res),
+                    // fallback to CPU in case of a timeout for winning_post task
+                    Err(SynthesisError::Scheduler(ClientError::Timeout))
+                        if task_type == Some(TaskType::WinningPost) =>
+                    {
+                        warn!("WinningPost timeout error -> falling back to CPU");
+                        self.use_cpu()
+                    }
+                    Err(SynthesisError::Scheduler(ClientError::NoGpuResources)) => {
+                        warn!("No supported GPU resources -> falling back to CPU");
+                        self.use_cpu()
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+
+            #[cfg(not(any(feature = "cuda", feature = "opencl")))]
+            pub fn solve(&mut self, _client: &mut Client) -> Result<(), SynthesisError> {
+                self.use_cpu()
+            }
+
+            fn use_cpu(&mut self) -> Result<(), SynthesisError> {
+                let mut kernel = self.kernel.take();
+                (self.call)(&mut kernel).map(|_| ())
+            }
+        }
+
+        #[cfg(any(feature = "cuda", feature = "opencl"))]
+        impl<E, F, R> TaskFunc for $class<E, F, R>
+        where
+            for<'a> F: FnMut(&'a mut Option<$kern<E>>) -> Result<R, SynthesisError>,
+            E: Engine + gpu::GpuEngine,
+        {
+            type Output = ();
+            type Error = SynthesisError;
+
+            fn init(&mut self, alloc: Option<&ResourceAlloc>) -> Result<Self::Output, Self::Error> {
+                self.kernel.replace($kern::<E>::new(self._log_d, alloc));
+                Ok(())
+            }
+            fn end(&mut self, _: Option<&ResourceAlloc>) -> Result<Self::Output, Self::Error> {
+                Ok(())
+            }
+            fn task(&mut self, _alloc: Option<&ResourceAlloc>) -> Result<TaskResult, Self::Error> {
+                let mut kernel = self.kernel.take();
+                let res = match (self.call)(&mut kernel) {
+                    Ok(_) => Ok(TaskResult::Done),
+                    Err(e) => Err(e),
+                };
+                res
+            }
+        }
+    };
+}
+
+// FFT Kernels use only one device
+solver!(FftSolver, LockedFFTKernel);
+// Multiexp kernels use all GPUS in the system
+// so does not pass a specific number of gpus to use.
+solver!(MultiexpSolver, LockedMultiexpKernel);

--- a/tests/gpu_provers.rs
+++ b/tests/gpu_provers.rs
@@ -39,8 +39,8 @@ impl<Scalar: PrimeField> Circuit<Scalar> for DummyDemo {
 #[test]
 pub fn test_parallel_prover() {
     use bellperson::groth16::{
-        create_random_proof, create_random_proof_in_priority, generate_random_parameters,
-        prepare_verifying_key, verify_proof,
+        create_random_proof, create_random_proof_with_type, generate_random_parameters,
+        prepare_verifying_key, verify_proof, BellTaskType,
     };
     use blstrs::Bls12;
     use rand::thread_rng;
@@ -80,7 +80,13 @@ pub fn test_parallel_prover() {
             let now = Instant::now();
 
             let rng = &mut thread_rng();
-            let proof_higher = create_random_proof_in_priority(c.clone(), &params, rng).unwrap();
+            let proof_higher = create_random_proof_with_type(
+                c.clone(),
+                &params,
+                rng,
+                Some(BellTaskType::WinningPost),
+            )
+            .unwrap();
             assert!(verify_proof(&pvk, &proof_higher, &[]).unwrap());
 
             println!(
@@ -88,9 +94,6 @@ pub fn test_parallel_prover() {
                 now.elapsed().as_secs(),
                 now.elapsed().subsec_millis()
             );
-
-            // Sleep in between higher proofs so that LOWER thread can acquire GPU again
-            thread::sleep(Duration::from_millis(3000));
         }
     });
 


### PR DESCRIPTION
this is a minimal integration with the scheduler. 
- refactor the `create_proof_batch_priority` function in `groth16/prover.rs` which contains 4 important blocks. the first one performs FFT operations . The other 3 blocks do `multiexp` operations. A 5th block generates the proofs, this does not use GPUs but uses the result of previous blocks. each of those blocks was refactored into an iterable function.
- remove the `src/gpu/locks.rs`, which is no longer needed, but the Locked suffix in `LockedFFTKernel` and `LockedMultiexpKernel `remains the same just to avoid even more refactoring.
- adds a new public function in the groth16 module that is used by rust-fil-proofs. it is there where all the calls from rust-fil-proofs end up. the TaskType parameter allows the scheduler to know what task it is going to plan and what resources the task can use exclusively. if the argument is `None`, the scheduler will assign the lowest priority(deadline) and whatever resource is available to the task.


