### PR TITLE
chore: add compile error for mutually exclusive features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,9 @@
 // Requires nightly for aarch64
 #![cfg_attr(target_arch = "aarch64", feature(stdsimd))]
 
+#[cfg(all(feature = "pairing", feature = "blst"))]
+compile_error!("pairing and blst features are mutually exclusive. Running with --no-default-features might help.");
+
 #[cfg(test)]
 #[macro_use]
 extern crate hex_literal;


### PR DESCRIPTION
Using the `pairing` and `blst` features together produces lots of
errors. This compile time error might help at least a bit to figure
out what is wrong.

The build error looks like this:

    error: pairing and blst features are mutually exclusive. Running with --no-default-features might help.
       --> src/lib.rs:140:1
        |
    140 | compile_error!("pairing and blst features are mutually exclusive. Running with --no-default-features might help.");
        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^