### PR TITLE
feat: use latest rust-gpu-tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ paired = { version = "0.22.0", optional = true }
 
 # gpu feature 
 #rust-gpu-tools = { version = "0.3.0", optional = true }
-rust-gpu-tools = { git = "https://github.com/filecoin-project/rust-gpu-tools", rev = "2827a11196dd638c9afe5aeb99f6425c0d1a7670", optional = true }
+rust-gpu-tools = { git = "https://github.com/filecoin-project/rust-gpu-tools", branch = "cuda", default-features = false, features = ["opencl"], optional = true }
 ff-cl-gen = { version = "0.3.0", optional = true }
 fs2 = { version = "0.4.3", optional = true }
 

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::upper_case_acronyms)]
 
 #[cfg(feature = "gpu")]
-use rust_gpu_tools::opencl;
+use rust_gpu_tools::GPUError as GpuToolsError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum GPUError {
@@ -9,7 +9,7 @@ pub enum GPUError {
     Simple(&'static str),
     #[cfg(feature = "gpu")]
     #[error("OpenCL Error: {0}")]
-    OpenCL(#[from] opencl::GPUError),
+    GpuTools(#[from] GpuToolsError),
     #[cfg(feature = "gpu")]
     #[error("GPU taken by a high priority process!")]
     GPUTaken,

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -1,5 +1,5 @@
 use log::{info, warn};
-use rust_gpu_tools::*;
+use rust_gpu_tools::{opencl, Device};
 use std::collections::HashMap;
 use std::env;
 
@@ -74,7 +74,7 @@ pub fn get_core_count(d: &opencl::Device) -> usize {
 }
 
 pub fn dump_device_list() {
-    for d in opencl::Device::all() {
+    for d in Device::all() {
         info!("Device: {:?}", d);
     }
 }


### PR DESCRIPTION
rust-gpu-tools now also supports CUDA. This lead to some API changes.
Most notable there is now a `Device` abstraction, which supports both,
CUDA and OpenCL devices.

Also when creating kernels, the way the global work size has changed.
it is no longer the total number of threads, but how many groups of
local work size sized threads there are.