### PR TITLE
fix: use yastl for thread pools instead of rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ paired = { version = "0.22.0", optional = true }
 rust-gpu-tools = { version = "0.4.0", optional = true }
 ff-cl-gen = { version = "0.3.0", optional = true }
 fs2 = { version = "0.4.3", optional = true }
+yastl = "0.1.2"
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -104,7 +104,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
             let minv = self.minv;
 
             for v in self.coeffs.chunks_mut(chunk) {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     for v in v {
                         v.group_mul_assign(&minv);
                     }
@@ -118,7 +118,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
     pub fn distribute_powers(&mut self, worker: &Worker, g: E::Fr) {
         worker.scope(self.coeffs.len(), |scope, chunk| {
             for (i, v) in self.coeffs.chunks_mut(chunk).enumerate() {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     let mut u = g.pow(&[(i * chunk) as u64]);
                     for v in v.iter_mut() {
                         v.group_mul_assign(&u);
@@ -170,7 +170,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
             for v in self.coeffs.chunks_mut(chunk) {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     for v in v {
                         v.group_mul_assign(&i);
                     }
@@ -189,7 +189,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
                 .chunks_mut(chunk)
                 .zip(other.coeffs.chunks(chunk))
             {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     for (a, b) in a.iter_mut().zip(b.iter()) {
                         a.group_mul_assign(&b.0);
                     }
@@ -208,7 +208,7 @@ impl<E: Engine, G: Group<E>> EvaluationDomain<E, G> {
                 .chunks_mut(chunk)
                 .zip(other.coeffs.chunks(chunk))
             {
-                scope.spawn(move |_| {
+                scope.execute(move || {
                     for (a, b) in a.iter_mut().zip(b.iter()) {
                         a.group_sub_assign(&b);
                     }
@@ -392,7 +392,7 @@ fn parallel_fft<E: ScalarEngine, T: Group<E>>(
         let a = &*a;
 
         for (j, tmp) in tmp.iter_mut().enumerate() {
-            scope.spawn(move |_scope| {
+            scope.execute(move || {
                 // Shuffle into a sub-FFT
                 let omega_j = omega.pow(&[j as u64]);
                 let omega_step = omega.pow(&[(j as u64) << log_new_n]);
@@ -420,7 +420,7 @@ fn parallel_fft<E: ScalarEngine, T: Group<E>>(
         let tmp = &tmp;
 
         for (idx, a) in a.chunks_mut(chunk).enumerate() {
-            scope.spawn(move |_scope| {
+            scope.execute(move || {
                 let mut idx = idx * chunk;
                 let mask = (1 << log_cpus) - 1;
                 for a in a {

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -288,7 +288,7 @@ where
 
         let mut acc = <G as CurveAffine>::Projective::zero();
 
-        let results = crate::multicore::THREAD_POOL.install(|| {
+        let results = crate::multicore::RAYON_THREAD_POOL.install(|| {
             if n > 0 {
                 bases
                 .par_chunks(chunk_size)

--- a/src/groth16/aggregate/macros.rs
+++ b/src/groth16/aggregate/macros.rs
@@ -3,10 +3,10 @@ macro_rules! try_par {
         $(
             let mut $name = None;
         )+
-            rayon::scope(|s| {
+            crate::multicore::THREAD_POOL.scoped(|s| {
                 $(
                     let $name = &mut $name;
-                    s.spawn(move |_| {
+                    s.execute(move || {
                         *$name = Some($f);
                     });)+
             });
@@ -21,10 +21,10 @@ macro_rules! par {
         $(
             let mut $name = None;
         )+
-            rayon::scope(|s| {
+            crate::multicore::THREAD_POOL.scoped(|s| {
                 $(
                     let $name = &mut $name;
-                    s.spawn(move |_| {
+                    s.execute(move || {
                         *$name = Some($f);
                     });)+
             });
@@ -38,11 +38,11 @@ macro_rules! par {
             let mut $name1 = None;
             let mut $name2 = None;
         )+
-            rayon::scope(|s| {
+            crate::multicore::THREAD_POOL.scoped(|s| {
                 $(
                     let $name1 = &mut $name1;
                     let $name2 = &mut $name2;
-                    s.spawn(move |_| {
+                    s.execute(move || {
                         let (a, b) = $f;
                         *$name1 = Some(a);
                         *$name2 = Some(b);

--- a/src/groth16/aggregate/srs.rs
+++ b/src/groth16/aggregate/srs.rs
@@ -267,39 +267,22 @@ pub fn setup_fake_srs<E: Engine, R: rand::RngCore>(rng: &mut R, size: usize) -> 
     let g = E::G1::one();
     let h = E::G2::one();
 
-    let mut g_alpha_powers = Vec::new();
-    let mut g_beta_powers = Vec::new();
-    let mut h_alpha_powers = Vec::new();
-    let mut h_beta_powers = Vec::new();
-    rayon::scope(|s| {
-        let alpha = &alpha;
-        let h = &h;
-        let g = &g;
-        let beta = &beta;
-        let g_alpha_powers = &mut g_alpha_powers;
-        s.spawn(move |_| {
-            *g_alpha_powers = structured_generators_scalar_power(2 * size, g, alpha);
-        });
-        let g_beta_powers = &mut g_beta_powers;
-        s.spawn(move |_| {
-            *g_beta_powers = structured_generators_scalar_power(2 * size, g, beta);
-        });
-
-        let h_alpha_powers = &mut h_alpha_powers;
-        s.spawn(move |_| {
-            *h_alpha_powers = structured_generators_scalar_power(2 * size, h, alpha);
-        });
-
-        let h_beta_powers = &mut h_beta_powers;
-        s.spawn(move |_| {
-            *h_beta_powers = structured_generators_scalar_power(2 * size, h, beta);
-        });
-    });
+    let alpha = &alpha;
+    let h = &h;
+    let g = &g;
+    let beta = &beta;
+    par! {
+        let g_alpha_powers = structured_generators_scalar_power(2 * size, g, alpha),
+        let g_beta_powers = structured_generators_scalar_power(2 * size, g, beta),
+        let h_alpha_powers = structured_generators_scalar_power(2 * size, h, alpha),
+        let h_beta_powers = structured_generators_scalar_power(2 * size, h, beta)
+    };
 
     debug_assert!(h_alpha_powers[0] == E::G2::one().into_affine());
     debug_assert!(h_beta_powers[0] == E::G2::one().into_affine());
     debug_assert!(g_alpha_powers[0] == E::G1::one().into_affine());
     debug_assert!(g_beta_powers[0] == E::G1::one().into_affine());
+
     GenericSRS {
         g_alpha_powers,
         g_beta_powers,

--- a/src/groth16/aggregate/verify.rs
+++ b/src/groth16/aggregate/verify.rs
@@ -73,118 +73,114 @@ pub fn verify_aggregate_proof<E: Engine + std::fmt::Debug, R: rand::RngCore + Se
     let pairing_checks = PairingChecks::new(rng);
     let pairing_checks_copy = &pairing_checks;
 
-    rayon::scope(move |_s| {
-        // 1.Check TIPA proof ab
-        // 2.Check TIPA proof c
-        //        s.spawn(move |_| {
-        let now = Instant::now();
-        verify_tipp_mipp::<E, R>(
-            ip_verifier_srs,
-            proof,
-            &r, // we give the extra r as it's not part of the proof itself - it is simply used on top for the groth16 aggregation
-            pairing_checks_copy,
-            &hcom,
-        );
-        debug!("TIPP took {} ms", now.elapsed().as_millis(),);
-        //        });
+    // 1.Check TIPA proof ab
+    // 2.Check TIPA proof c
+    //        s.spawn(move |_| {
+    let now = Instant::now();
+    verify_tipp_mipp::<E, R>(
+        ip_verifier_srs,
+        proof,
+        &r, // we give the extra r as it's not part of the proof itself - it is simply used on top for the groth16 aggregation
+        pairing_checks_copy,
+        &hcom,
+    );
+    debug!("TIPP took {} ms", now.elapsed().as_millis(),);
 
-        // Check aggregate pairing product equation
-        // SUM of a geometric progression
-        // SUM a^i = (1 - a^n) / (1 - a) = -(1-a^n)/-(1-a)
-        // = (a^n - 1) / (a - 1)
-        info!("checking aggregate pairing");
-        let mut r_sum = r.pow(&[public_inputs.len() as u64]);
-        r_sum.sub_assign(&E::Fr::one());
-        let b = sub!(*r, &E::Fr::one()).inverse().unwrap();
-        r_sum.mul_assign(&b);
+    // Check aggregate pairing product equation
+    // SUM of a geometric progression
+    // SUM a^i = (1 - a^n) / (1 - a) = -(1-a^n)/-(1-a)
+    // = (a^n - 1) / (a - 1)
+    info!("checking aggregate pairing");
+    let mut r_sum = r.pow(&[public_inputs.len() as u64]);
+    r_sum.sub_assign(&E::Fr::one());
+    let b = sub!(*r, &E::Fr::one()).inverse().unwrap();
+    r_sum.mul_assign(&b);
 
-        // The following parts 3 4 5 are independently computing the parts of the Groth16
-        // verification equation
-        // NOTE From this point on, we are only checking *one* pairing check (the Groth16
-        // verification equation) so we don't need to randomize as all other checks are being
-        // randomized already. When merging all pairing checks together, this will be the only one
-        // non-randomized.
-        //
-        let (r_vec_sender, r_vec_receiver) = bounded(1);
-        //        s.spawn(move |_| {
-        let now = Instant::now();
-        r_vec_sender
-            .send(structured_scalar_power(public_inputs.len(), &*r))
-            .unwrap();
-        let elapsed = now.elapsed().as_millis();
-        debug!("generation of r vector: {}ms", elapsed);
-        //        });
+    // The following parts 3 4 5 are independently computing the parts of the Groth16
+    // verification equation
+    // NOTE From this point on, we are only checking *one* pairing check (the Groth16
+    // verification equation) so we don't need to randomize as all other checks are being
+    // randomized already. When merging all pairing checks together, this will be the only one
+    // non-randomized.
+    //
+    let (r_vec_sender, r_vec_receiver) = bounded(1);
 
-        par! {
-            // 3. Compute left part of the final pairing equation
-            let left = {
-                let mut alpha_g1_r_sum = pvk.alpha_g1;
-                alpha_g1_r_sum.mul_assign(r_sum);
+    let now = Instant::now();
+    r_vec_sender
+        .send(structured_scalar_power(public_inputs.len(), &*r))
+        .unwrap();
+    let elapsed = now.elapsed().as_millis();
+    debug!("generation of r vector: {}ms", elapsed);
 
-                E::miller_loop(&[(&alpha_g1_r_sum.into_affine().prepare(), &pvk.beta_g2)])
-            },
-            // 4. Compute right part of the final pairing equation
-            let right = {
-                E::miller_loop(&[(
-                    // e(c^r vector form, h^delta)
-                    // let agg_c = inner_product::multiexponentiation::<E::G1Affine>(&c, r_vec)
-                    &proof.agg_c.into_affine().prepare(),
-                    &pvk.delta_g2,
-                )])
-            },
-            // 5. compute the middle part of the final pairing equation, the one
-            //    with the public inputs
-            let middle = {
-                    // We want to compute MUL(i:0 -> l) S_i ^ (SUM(j:0 -> n) ai,j * r^j)
-                    // this table keeps tracks of incremental computation of each i-th
-                    // exponent to later multiply with S_i
-                    // The index of the table is i, which is an index of the public
-                    // input element
-                    // We incrementally build the r vector and the table
-                    // NOTE: in this version it's not r^2j but simply r^j
+    par! {
+        // 3. Compute left part of the final pairing equation
+        let left = {
+            let mut alpha_g1_r_sum = pvk.alpha_g1;
+            alpha_g1_r_sum.mul_assign(r_sum);
 
-                    let l = public_inputs[0].len();
-                    let mut g_ic = pvk.ic_projective[0];
-                    g_ic.mul_assign(r_sum);
+            E::miller_loop(&[(&alpha_g1_r_sum.into_affine().prepare(), &pvk.beta_g2)])
+        },
+        // 4. Compute right part of the final pairing equation
+        let right = {
+            E::miller_loop(&[(
+                // e(c^r vector form, h^delta)
+                // let agg_c = inner_product::multiexponentiation::<E::G1Affine>(&c, r_vec)
+                &proof.agg_c.into_affine().prepare(),
+                &pvk.delta_g2,
+            )])
+        },
+        // 5. compute the middle part of the final pairing equation, the one
+        //    with the public inputs
+        let middle = {
+                // We want to compute MUL(i:0 -> l) S_i ^ (SUM(j:0 -> n) ai,j * r^j)
+                // this table keeps tracks of incremental computation of each i-th
+                // exponent to later multiply with S_i
+                // The index of the table is i, which is an index of the public
+                // input element
+                // We incrementally build the r vector and the table
+                // NOTE: in this version it's not r^2j but simply r^j
 
-                    let powers = r_vec_receiver.recv().unwrap();
+                let l = public_inputs[0].len();
+                let mut g_ic = pvk.ic_projective[0];
+                g_ic.mul_assign(r_sum);
 
-                    let now = Instant::now();
-                    // now we do the multi exponentiation
-                    let getter = |i: usize| -> <E::Fr as PrimeField>::Repr {
-                        // i denotes the column of the public input, and j denotes which public input
-                        let mut c = public_inputs[0][i];
-                        for j in 1..public_inputs.len() {
-                            let mut ai = public_inputs[j][i];
-                            ai.mul_assign(&powers[j]);
-                            c.add_assign(&ai);
-                        }
-                        c.into_repr()
-                    };
+                let powers = r_vec_receiver.recv().unwrap();
 
-                    let totsi = par_multiscalar::<_, E::G1Affine>(
-                        &ScalarList::Getter(getter, l),
-                        &pvk.multiscalar.at_point(1),
-                        std::mem::size_of::<<E::Fr as PrimeField>::Repr>() * 8,
-                    );
+                let now = Instant::now();
+                // now we do the multi exponentiation
+                let getter = |i: usize| -> <E::Fr as PrimeField>::Repr {
+                    // i denotes the column of the public input, and j denotes which public input
+                    let mut c = public_inputs[0][i];
+                    for j in 1..public_inputs.len() {
+                        let mut ai = public_inputs[j][i];
+                        ai.mul_assign(&powers[j]);
+                        c.add_assign(&ai);
+                    }
+                    c.into_repr()
+                };
 
-                    g_ic.add_assign(&totsi);
+                let totsi = par_multiscalar::<_, E::G1Affine>(
+                    &ScalarList::Getter(getter, l),
+                    &pvk.multiscalar.at_point(1),
+                    std::mem::size_of::<<E::Fr as PrimeField>::Repr>() * 8,
+                );
 
-                    let ml = E::miller_loop(&[(&g_ic.into_affine().prepare(), &pvk.gamma_g2)]);
-                    let elapsed = now.elapsed().as_millis();
-                    debug!("table generation: {}ms", elapsed);
+                g_ic.add_assign(&totsi);
 
-                    ml
-            }
-        };
+                let ml = E::miller_loop(&[(&g_ic.into_affine().prepare(), &pvk.gamma_g2)]);
+                let elapsed = now.elapsed().as_millis();
+                debug!("table generation: {}ms", elapsed);
 
-        pairing_checks_copy.merge_nonrandom(
-            vec![left, middle, right],
-            // final value ip_ab is what we want to compare in the groth16
-            // aggregated equation A * B
-            proof.ip_ab,
-        );
-    });
+                ml
+        }
+    };
+
+    pairing_checks_copy.merge_nonrandom(
+        vec![left, middle, right],
+        // final value ip_ab is what we want to compare in the groth16
+        // aggregated equation A * B
+        proof.ip_ab,
+    );
 
     let res = pairing_checks.verify();
     info!("aggregate verify done");

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -242,7 +242,7 @@ where
             let powers_of_tau = powers_of_tau.as_mut();
             worker.scope(powers_of_tau.len(), |scope, chunk| {
                 for (i, powers_of_tau) in powers_of_tau.chunks_mut(chunk).enumerate() {
-                    scope.spawn(move |_scope| {
+                    scope.execute(move || {
                         let mut current_tau_power = tau.pow(&[(i * chunk) as u64]);
 
                         for p in powers_of_tau {
@@ -266,7 +266,7 @@ where
             {
                 let mut g1_wnaf = g1_wnaf.shared();
 
-                scope.spawn(move |_scope| {
+                scope.execute(move || {
                     // Set values of the H query to g1^{(tau^i * t(tau)) / delta}
                     for (h, p) in h.iter_mut().zip(p.iter()) {
                         // Compute final exponent
@@ -346,7 +346,7 @@ where
                 let mut g1_wnaf = g1_wnaf.shared();
                 let mut g2_wnaf = g2_wnaf.shared();
 
-                scope.spawn(move |_scope| {
+                scope.execute(move || {
                     for ((((((a, b_g1), b_g2), ext), at), bt), ct) in a
                         .iter_mut()
                         .zip(b_g1.iter_mut())

--- a/src/groth16/proof.rs
+++ b/src/groth16/proof.rs
@@ -80,12 +80,13 @@ impl<E: Engine> Proof<E> {
     }
 
     pub fn read_many(proof_bytes: &[u8], num_proofs: usize) -> io::Result<Vec<Self>> {
-        use crate::multicore::THREAD_POOL;
+        use crate::multicore::RAYON_THREAD_POOL;
         use rayon::prelude::*;
+
         debug_assert_eq!(proof_bytes.len(), num_proofs * Self::size());
 
         // Decompress and group check in parallel
-        THREAD_POOL.install(|| {
+        RAYON_THREAD_POOL.install(|| {
             #[derive(Clone, Copy)]
             enum ProofPart<E: Engine> {
                 A(E::G1Affine),

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use super::{ParameterSource, Proof};
 use crate::domain::{EvaluationDomain, Scalar};
 use crate::gpu::{LockedFFTKernel, LockedMultiexpKernel};
-use crate::multicore::{Worker, THREAD_POOL};
+use crate::multicore::{Worker, RAYON_THREAD_POOL};
 use crate::multiexp::{multiexp, DensityTracker, FullDensity};
 use crate::{
     Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable, BELLMAN_VERSION,
@@ -278,7 +278,7 @@ where
     // Preparing things for the proofs is done a lot in parallel with the help of Rayon. Make
     // sure that those things run on the correct thread pool.
     let (start, mut provers, input_assignments, aux_assignments) =
-        THREAD_POOL.install(|| create_proof_batch_priority_inner(circuits))?;
+        RAYON_THREAD_POOL.install(|| create_proof_batch_priority_inner(circuits))?;
 
     // The rest of the proving also has parallelism, but not on the outer loops, but within e.g. the
     // multiexp calculations. This is what the `Worker` is used for. It is important that calling

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -17,7 +17,7 @@ lazy_static! {
     static ref NUM_CPUS: usize = env::var("BELLMAN_NUM_CPUS")
         .ok()
         .and_then(|num| num.parse().ok())
-        .unwrap_or_else(|| num_cpus::get());
+        .unwrap_or_else(num_cpus::get);
     pub static ref THREAD_POOL: Pool = Pool::new(*NUM_CPUS);
     pub static ref VERIFIER_POOL: Pool = Pool::new(NUM_CPUS.max(MAX_VERIFIER_THREADS));
     pub static ref RAYON_THREAD_POOL: rayon::ThreadPool = rayon::ThreadPoolBuilder::new()

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -5,35 +5,25 @@
 //!
 //! [`CpuPool`]: futures_cpupool::CpuPool
 
-use crossbeam_channel::{bounded, Receiver};
-use lazy_static::lazy_static;
-use log::{error, trace};
 use std::env;
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use crossbeam_channel::{bounded, Receiver};
+use lazy_static::lazy_static;
+use yastl::Pool;
 
-static WORKER_SPAWN_COUNTER: AtomicUsize = AtomicUsize::new(0);
+const MAX_VERIFIER_THREADS: usize = 6;
 
 lazy_static! {
-    static ref NUM_CPUS: usize = if let Ok(num) = env::var("BELLMAN_NUM_CPUS") {
-        if let Ok(num) = num.parse() {
-            num
-        } else {
-            num_cpus::get()
-        }
-    } else {
-        num_cpus::get()
-    };
-    // See Worker::compute below for a description of this.
-    static ref WORKER_SPAWN_MAX_COUNT: usize = *NUM_CPUS * 4;
-    pub static ref THREAD_POOL: rayon::ThreadPool = rayon::ThreadPoolBuilder::new()
+    static ref NUM_CPUS: usize = env::var("BELLMAN_NUM_CPUS")
+        .ok()
+        .and_then(|num| num.parse().ok())
+        .unwrap_or_else(|| num_cpus::get());
+    pub static ref THREAD_POOL: Pool = Pool::new(*NUM_CPUS);
+    pub static ref VERIFIER_POOL: Pool = Pool::new(NUM_CPUS.max(MAX_VERIFIER_THREADS));
+    pub static ref RAYON_THREAD_POOL: rayon::ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(*NUM_CPUS)
         .build()
-        .unwrap();
-    pub static ref VERIFIER_POOL: rayon::ThreadPool = rayon::ThreadPoolBuilder::new()
-        .num_threads(NUM_CPUS.max(6))
-        .build()
-        .unwrap();
+        .expect("failed to build rayon threadpool");
 }
 
 #[derive(Clone, Default)]
@@ -55,52 +45,17 @@ impl Worker {
     {
         let (sender, receiver) = bounded(1);
 
-        let thread_index = if THREAD_POOL.current_thread_index().is_some() {
-            THREAD_POOL.current_thread_index().unwrap()
-        } else {
-            0
-        };
-
-        // We keep track here of how many times spawn has been called.
-        // It can be called without limit, each time, putting a
-        // request for a new thread to execute a method on the
-        // ThreadPool.  However, if we allow it to be called without
-        // limits, we run the risk of memory exhaustion due to limited
-        // stack space consumed by all of the pending closures to be
-        // executed.
-        let previous_count = WORKER_SPAWN_COUNTER.fetch_add(1, Ordering::SeqCst);
-
-        // If the number of spawns requested has exceeded the number
-        // of cores available for processing by some factor (the
-        // default being 4), instead of requesting that we spawn a new
-        // thread, we instead execute the closure in the context of an
-        // install call to help clear the growing work queue and
-        // minimize the chances of memory exhaustion.
-        if previous_count > *WORKER_SPAWN_MAX_COUNT {
-            THREAD_POOL.install(move || {
-                trace!("[{}] switching to install to help clear backlog[current threads {}, threads requested {}]",
-                       thread_index,
-                       THREAD_POOL.current_num_threads(),
-                       WORKER_SPAWN_COUNTER.load(Ordering::SeqCst));
-                let res = f();
-                sender.send(res).unwrap();
-                WORKER_SPAWN_COUNTER.fetch_sub(1, Ordering::SeqCst);
-            });
-        } else {
-            THREAD_POOL.spawn(move || {
-                let res = f();
-                sender.send(res).unwrap();
-                WORKER_SPAWN_COUNTER.fetch_sub(1, Ordering::SeqCst);
-            });
-        }
+        THREAD_POOL.spawn(move || {
+            let res = f();
+            sender.send(res).unwrap();
+        });
 
         Waiter { receiver }
     }
 
     pub fn scope<'a, F, R>(&self, elements: usize, f: F) -> R
     where
-        F: FnOnce(&rayon::Scope<'a>, usize) -> R + Send,
-        R: Send,
+        F: FnOnce(&yastl::Scope<'a>, usize) -> R,
     {
         let chunk_size = if elements < *NUM_CPUS {
             1
@@ -108,7 +63,7 @@ impl Worker {
             elements / *NUM_CPUS
         };
 
-        THREAD_POOL.scope(|scope| f(scope, chunk_size))
+        THREAD_POOL.scoped(|scope| f(scope, chunk_size))
     }
 }
 
@@ -119,11 +74,6 @@ pub struct Waiter<T> {
 impl<T> Waiter<T> {
     /// Wait for the result.
     pub fn wait(&self) -> T {
-        if THREAD_POOL.current_thread_index().is_some() {
-            // Calling `wait()` from within the worker thread pool can lead to dead logs
-            error!("The wait call should never be done inside the worker thread pool");
-            debug_assert!(false);
-        }
         self.receiver.recv().unwrap()
     }
 


### PR DESCRIPTION
In testing this removes the observed deadlocks in all cases so far. The thread pool does not use job stealing, and is much simpler. 

We will need to do benchmarks to see if there is any performance loss at the e2e perf.