### PR TITLE
fix: make kernels work with blst and 32-bit limbs

### DIFF
--- a/src/gpu/multiexp/ec.cl
+++ b/src/gpu/multiexp/ec.cl
@@ -9,9 +9,9 @@ typedef struct {
   FIELD y;
   #ifndef BLSTRS
     bool inf;
-  #endif
-  #if FIELD_LIMB_BITS == 32
-    uint _padding;
+    #if FIELD_LIMB_BITS == 32
+      uint _padding;
+    #endif
   #endif
 } POINT_affine;
 


### PR DESCRIPTION
On non Nvidia devices, 32-bit limbs are used. When the `blst` feature is
enabled, the calculations are wrong as there is some padding added, that
is only needed for the `pairing` feature.