### PR TITLE
feat: Add CUDA support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
           name: Set the PATH env variable
           command: |
             # Also put the Rust LLVM tools into the PATH.
-            echo 'export PATH="$HOME:~/.cargo/bin:~/.rustup/toolchains/<< pipeline.parameters.nightly-version >>-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:$PATH"' | tee --append $BASH_ENV
+            echo 'export PATH="$HOME:~/.cargo/bin:~/.rustup/toolchains/<< pipeline.parameters.nightly-version >>-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:/usr/local/cuda-11.2/bin:$PATH"' | tee --append $BASH_ENV
             source $BASH_ENV
 
   install-gpu-deps:
@@ -41,50 +41,9 @@ commands:
           name: Install libraries for GPU tests
           command: |
             sudo apt update
-            sudo apt-get update -y
             sudo apt install -y ocl-icd-opencl-dev
 
-  test_target_blst:
-    parameters:
-      target:
-        type: string
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - run:
-          name: Test blst (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test --all
-          no_output_timeout: 15m
-
-  test_target_blst_gpu:
-    parameters:
-      target:
-        type: string
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - run:
-          name: Test blst (GPU) (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test --all --release --features gpu
-          no_output_timeout: 30m
-
-  test_target_blst_ignored:
-    parameters:
-      target:
-        type: string
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - run:
-          name: Test blst ignored (<< parameters.target >>)
-          command: TARGET=<< parameters.target >> cargo test --release -- --ignored
-          no_output_timeout: 30m
-      - run:
-          name: Show results
-          command: cat aggregation.csv
-
 jobs:
-
   cargo_fetch:
     executor: default
     steps:
@@ -122,29 +81,46 @@ jobs:
             - "~/.cargo"
             - "~/.rustup"
 
-  test_blst_x86_64-unknown-linux-gnu:
+  test:
     executor: default
+    parameters:
+      cargo-args:
+        description: Addtional arguments for the cargo command
+        type: string
+        default: ""
+      framework:
+        description: Whether to use CUDA or OpenCL
+        type: string
+        default: ""
+    environment:
+      RUST_LOG: debug
+      # Build the kernel only for the single architecture that is used on CI. This should reduce
+      # the overall compile-time significantly.
+      BELLMAN_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
     steps:
       - set-env-path
       - install-gpu-deps
-      - test_target_blst:
-          target: "x86_64-unknown-linux-gnu"
+      - *restore-workspace
+      - *restore-cache
+      - run:
+          name: Test << parameters.framework>> with << parameters.cargo-args >>
+          command: BELLMAN_GPU_FRAMEWORK=<< parameters.framework >> cargo test << parameters.cargo-args >>
 
-  test_blst_gpu_x86_64-unknown-linux-gnu:
+  test_ignored:
     executor: default
+    environment:
+      RUST_LOG: debug
     steps:
       - set-env-path
-      - install-gpu-deps
-      - test_target_blst_gpu:
-          target: "x86_64-unknown-linux-gnu"
-
-  test_blst_ignored_x86_64-unknown-linux-gnu:
-    executor: default
-    steps:
-      - set-env-path
-      - install-gpu-deps
-      - test_target_blst_ignored:
-          target: "x86_64-unknown-linux-gnu"
+      - *restore-workspace
+      - *restore-cache
+      - run:
+          name: Test ignored
+          command: cargo test --release -- --ignored
+          no_output_timeout: 30m
+      - run:
+          name: Show results
+          command: cat aggregation.csv
 
   rustfmt:
     executor: default
@@ -158,6 +134,11 @@ jobs:
 
   clippy:
     executor: default
+    environment:
+      RUST_LOG: debug
+      # Build the kernel only for the single architecture that is used on CI. This should reduce
+      # the overall compile-time significantly.
+      BELLMAN_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
     steps:
       - *restore-workspace
       - *restore-cache
@@ -166,8 +147,14 @@ jobs:
           name: Run cargo clippy (default features)
           command: cargo clippy --all --all-targets -- -D warnings
       - run:
-          name: Run cargo clippy (gpu)
-          command: cargo clippy --all --all-targets --features gpu -- -D warnings
+          name: Run cargo clippy (opencl)
+          command: cargo clippy --all --all-targets --features opencl -- -D warnings
+      - run:
+          name: Run cargo clippy (cuda)
+          command: cargo clippy --all --all-targets --features cuda -- -D warnings
+      - run:
+          name: Run cargo clippy (cuda,opencl)
+          command: cargo clippy --all --all-targets --features cuda,opencl -- -D warnings
 
   coverage_run:
     executor: default
@@ -230,17 +217,36 @@ workflows:
       - clippy:
           requires:
             - cargo_fetch
-            
-      - test_blst_x86_64-unknown-linux-gnu:
+      - test:
+          name: "Test CPU"
+          cargo-args: "--workspace"
           requires:
             - cargo_fetch
-      - test_blst_gpu_x86_64-unknown-linux-gnu:
+      - test:
+          name: "Test OpenCL only"
+          cargo-args: "--workspace --release --features opencl"
           requires:
             - cargo_fetch
-      - test_blst_ignored_x86_64-unknown-linux-gnu:
+      - test:
+          name: "Test CUDA only"
+          cargo-args: "--release --features cuda"
           requires:
             - cargo_fetch
-
+      - test:
+          name: "Test CUDA/OpenCL (CUDA at run-time)"
+          cargo-args: "--release --features cuda,opencl"
+          framework: cuda
+          requires:
+            - cargo_fetch
+      - test:
+          name: "Test CUDA/OpenCL (OpenCL at run-time)"
+          cargo-args: "--release --features cuda,opencl"
+          framework: opencl
+          requires:
+            - cargo_fetch
+      - test_ignored:
+          requires:
+            - cargo_fetch
       #- coverage_run:
       #    name: coverage_default_features
       #    requires:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master"
 pairing = "0.21"
 yastl = "0.1.2"
 
-# gpu feature 
-rust-gpu-tools = { version = "0.4.0", optional = true }
+# cuda/opencl feature
+rust-gpu-tools = { git = "https://github.com/filecoin-project/rust-gpu-tools", branch = "master", default-features = false, optional = true }
 ec-gpu = { git = "https://github.com/filecoin-project/ec-gpu", branch = "master", optional = true }
 ec-gpu-gen = { git = "https://github.com/filecoin-project/ec-gpu", branch = "master", optional = true }
 fs2 = { version = "0.4.3", optional = true }
@@ -55,9 +55,19 @@ csv = "1.1.5"
 tempfile = "3.1.0"
 subtle = "2.2.1"
 
+[build-dependencies]
+blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
+execute = "0.2.9"
+ec-gpu = { git = "https://github.com/filecoin-project/ec-gpu", branch = "master", optional = true }
+ec-gpu-gen = { git = "https://github.com/filecoin-project/ec-gpu", branch = "master", optional = true }
+hex = "0.4"
+sha2 = "0.9"
+
+
 [features]
 default = ["groth16"]
-gpu = ["rust-gpu-tools", "ec-gpu", "ec-gpu-gen", "fs2", "blstrs/gpu"]
+cuda = ["rust-gpu-tools/cuda", "ec-gpu", "ec-gpu-gen", "fs2", "blstrs/gpu"]
+opencl = ["rust-gpu-tools/opencl", "ec-gpu", "ec-gpu-gen", "fs2", "blstrs/gpu"]
 groth16 = []
 
 # This feature disables/modifies long running tests to make the suitable for code coverage

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There is currently one backend available for the implementation of Bls12 381:
 
 ## GPU
 
-This fork contains GPU parallel acceleration to the FFT and Multiexponentation algorithms in the groth16 prover codebase under the compilation feature `gpu`.
+This fork contains GPU parallel acceleration to the FFT and Multiexponentation algorithms in the groth16 prover codebase under the compilation features `cuda` and `opencl`.
 
 ### Requirements
 - NVIDIA or AMD GPU Graphics Driver
@@ -62,13 +62,32 @@ The gpu extension contains some env vars that may be set externally to this libr
     ```
 
 - `RAYON_NUM_THREADS`
-   
+
    Restricts the number of threads used in the library to roughly twice that number (best effort). In the past this was done using `BELLMAN_NUM_CPUS` which is now deprecated. The default is set to the number of logical cores reported on the machine.
-   
+
    ```rust
     // Example
     env::set_var("RAYON_NUM_THREADS", "6");
    ```
+
+ - `BELLMAN_GPU_FRAMEWORK`
+
+     Bellman can be compiled with both, OpenCL and CUDA support. When both are available, `BELLMAN_GPU_FRAMEWORK` can be used to set it to a specific one, either `cuda` or `opencl`.
+
+    ```rust
+    // Example
+    env::set_var("BELLMAN_GPU_FRAMEWORK", "opencl");
+    ```
+
+ - `BELLMAN_CUDA_NVCC_ARGS`
+
+     By default the CUDA kernel is compiled for several architectures, which may take a long time. `BELLMAN_CUDA_NVCC_ARGS` can be used to override those arguments. The input and output file will still be automatically set.
+
+    ```rust
+    // Example for compiling the kernel for only the Turing architecture
+    env::set_var("BELLMAN_CUDA_NVCC_ARGS", "--fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75");
+    ```
+
 
 #### Supported / Tested Cards
 
@@ -107,21 +126,21 @@ Depending on the size of the proof being passed to the gpu for work, certain car
 RUSTFLAGS="-C target-cpu=native" cargo test --release --all
 ```
 
-To run using `gpu`, you can use:
+To run using CUDA and OpenCL, you can use:
 
 ```bash
-RUSTFLAGS="-C target-cpu=native" cargo test --release --all --features gpu
+RUSTFLAGS="-C target-cpu=native" cargo test --release --all --features cuda,opencl
 ```
 
 To run the multiexp_consistency test you can use:
 
 ```bash
-RUST_LOG=info cargo test --features gpu -- --exact multiexp::gpu_multiexp_consistency --nocapture
+RUST_LOG=info cargo test --features cuda,opencl -- --exact multiexp::gpu_multiexp_consistency --nocapture
 ```
 
 ### Considerations
 
-Bellperson uses `rust-gpu-tools` as its OpenCL backend, therefore you may see a
+Bellperson uses `rust-gpu-tools` as its CUDA/OpenCL backend, therefore you may see a
 directory named `~/.rust-gpu-tools` in your home folder, which contains the
 compiled binaries of OpenCL kernels used in this repository.
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,84 @@
+/// The build script is needed to compile the CUDA kernel.
+
+#[cfg(feature = "cuda")]
+fn main() {
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::{env, fs};
+
+    use blstrs::Bls12;
+    use ec_gpu_gen::Limb32;
+    use sha2::{Digest, Sha256};
+
+    #[path = "src/gpu/sources.rs"]
+    mod sources;
+
+    let kernel_source = sources::kernel::<Bls12, Limb32>();
+
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR was not set.");
+
+    // Make it possible to override the default options. Though the source and output file is
+    // always set automatically.
+    let mut nvcc = match env::var("BELLMAN_CUDA_NVCC_ARGS") {
+        Ok(args) => execute::command(format!("nvcc {}", args)),
+        Err(_) => {
+            let mut command = Command::new("nvcc");
+            command
+                .arg("--optimize=6")
+                .arg("--fatbin")
+                .arg("--gpu-architecture=sm_86")
+                .arg("--generate-code=arch=compute_86,code=sm_86")
+                .arg("--generate-code=arch=compute_80,code=sm_80")
+                .arg("--generate-code=arch=compute_75,code=sm_75");
+            command
+        }
+    };
+
+    // Hash the source and and the compile flags. Use that as the filename, so that the kernel is
+    // only rebuilt if any of them change.
+    let mut hasher = Sha256::new();
+    hasher.update(kernel_source.as_bytes());
+    hasher.update(&format!("{:?}", &nvcc));
+    let kernel_digest = hex::encode(hasher.finalize());
+
+    let source_path: PathBuf = [&out_dir, &format!("{}.cu", &kernel_digest)]
+        .iter()
+        .collect();
+    let fatbin_path: PathBuf = [&out_dir, &format!("{}.fatbin", &kernel_digest)]
+        .iter()
+        .collect();
+
+    fs::write(&source_path, &kernel_source).unwrap_or_else(|_| {
+        panic!(
+            "Cannot write kernel source at {}.",
+            source_path.to_str().unwrap()
+        )
+    });
+
+    // Only compile if the output doesn't exist yet.
+    if !fatbin_path.as_path().exists() {
+        let status = nvcc
+            .arg("--output-file")
+            .arg(&fatbin_path)
+            .arg(&source_path)
+            .status()
+            .expect("Cannot run nvcc.");
+
+        if !status.success() {
+            panic!(
+                "nvcc failed. See the kernel source at {}",
+                source_path.to_str().unwrap()
+            );
+        }
+    }
+
+    // The idea to put the path to the farbin into a compile-time env variable is from
+    // https://github.com/LutzCle/fast-interconnects-demo/blob/b80ea8e04825167f486ab8ac1b5d67cf7dd51d2c/rust-demo/build.rs
+    println!(
+        "cargo:rustc-env=CUDA_MULTIEXP_FATBIN={}",
+        fatbin_path.to_str().unwrap()
+    );
+}
+
+#[cfg(not(feature = "cuda"))]
+fn main() {}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -567,7 +567,7 @@ where
     }
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 #[cfg(test)]
 mod tests {
     use crate::domain::{gpu_fft, parallel_fft, serial_fft, EvaluationDomain, Scalar};

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -1,19 +1,19 @@
 #![allow(clippy::upper_case_acronyms)]
 
-#[cfg(feature = "gpu")]
-use rust_gpu_tools::opencl;
+#[cfg(any(feature = "cuda", feature = "opencl"))]
+use rust_gpu_tools::GPUError as GpuToolsError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum GPUError {
     #[error("GPUError: {0}")]
     Simple(&'static str),
-    #[cfg(feature = "gpu")]
-    #[error("OpenCL Error: {0}")]
-    OpenCL(#[from] opencl::GPUError),
-    #[cfg(feature = "gpu")]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
+    #[error("GPU tools error: {0}")]
+    GpuTools(#[from] GpuToolsError),
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     #[error("GPU taken by a high priority process!")]
     GPUTaken,
-    #[cfg(feature = "gpu")]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     #[error("No kernel is initialized!")]
     KernelUninitialized,
     #[error("GPU accelerator is disabled!")]
@@ -22,7 +22,7 @@ pub enum GPUError {
 
 pub type GPUResult<T> = std::result::Result<T, GPUError>;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 impl From<std::boxed::Box<dyn std::any::Any + std::marker::Send>> for GPUError {
     fn from(e: std::boxed::Box<dyn std::any::Any + std::marker::Send>) -> Self {
         match e.downcast::<Self>() {

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -1,11 +1,11 @@
 use crate::gpu::{
     error::{GPUError, GPUResult},
-    locks, sources, GpuEngine,
+    locks, program, GpuEngine,
 };
 use ff::Field;
 use log::info;
 use pairing::Engine;
-use rust_gpu_tools::*;
+use rust_gpu_tools::{program_closures, Device, LocalBuffer, Program};
 use std::cmp;
 use std::ops::MulAssign;
 
@@ -18,11 +18,10 @@ pub struct FFTKernel<E>
 where
     E: Engine + GpuEngine,
 {
-    program: opencl::Program,
-    pq_buffer: opencl::Buffer<E::Fr>,
-    omegas_buffer: opencl::Buffer<E::Fr>,
+    program: Program,
     _lock: locks::GPULock, // RFC 1857: struct fields are dropped in the same order as they are declared.
     priority: bool,
+    _phantom: std::marker::PhantomData<E>,
 }
 
 impl<E> FFTKernel<E>
@@ -32,122 +31,100 @@ where
     pub fn create(priority: bool) -> GPUResult<FFTKernel<E>> {
         let lock = locks::GPULock::lock();
 
-        let devices = opencl::Device::all();
-        if devices.is_empty() {
-            return Err(GPUError::Simple("No working GPUs found!"));
-        }
-
         // Select the first device for FFT
-        let device = devices[0];
+        let device = *Device::all()
+            .first()
+            .ok_or(GPUError::Simple("No working GPUs found!"))?;
 
-        let src = sources::kernel::<E>(device.vendor() == opencl::Vendor::Nvidia);
-
-        let program = opencl::Program::from_opencl(&device, &src)?;
-        let pq_buffer = program.create_buffer::<E::Fr>(1 << MAX_LOG2_RADIX >> 1)?;
-        let omegas_buffer = program.create_buffer::<E::Fr>(LOG2_MAX_ELEMENTS)?;
+        let program = program::program::<E>(&device)?;
 
         info!("FFT: 1 working device(s) selected.");
         info!("FFT: Device 0: {}", device.name());
 
         Ok(FFTKernel {
             program,
-            pq_buffer,
-            omegas_buffer,
             _lock: lock,
             priority,
+            _phantom: std::marker::PhantomData,
         })
     }
 
-    /// Peforms a FFT round
-    /// * `log_n` - Specifies log2 of number of elements
-    /// * `log_p` - Specifies log2 of `p`, (http://www.bealto.com/gpu-fft_group-1.html)
-    /// * `deg` - 1=>radix2, 2=>radix4, 3=>radix8, ...
-    /// * `max_deg` - The precalculated values pq` and `omegas` are valid for radix degrees up to `max_deg`
-    fn radix_fft_round(
-        &mut self,
-        src_buffer: &opencl::Buffer<E::Fr>,
-        dst_buffer: &opencl::Buffer<E::Fr>,
-        log_n: u32,
-        log_p: u32,
-        deg: u32,
-        max_deg: u32,
-    ) -> GPUResult<()> {
-        if locks::PriorityLock::should_break(self.priority) {
-            return Err(GPUError::GPUTaken);
-        }
-
-        let n = 1u32 << log_n;
-        let local_work_size = 1 << cmp::min(deg - 1, MAX_LOG2_LOCAL_WORK_SIZE);
-        let global_work_size = n >> deg;
-        let kernel = self.program.create_kernel(
-            "radix_fft",
-            global_work_size as usize,
-            local_work_size as usize,
-        )?;
-        kernel
-            .arg(src_buffer)
-            .arg(dst_buffer)
-            .arg(&self.pq_buffer)
-            .arg(&self.omegas_buffer)
-            .arg(&opencl::LocalBuffer::<E::Fr>::new(1 << deg))
-            .arg(&n)
-            .arg(&log_p)
-            .arg(&deg)
-            .arg(&max_deg)
-            .run()?;
-        Ok(())
-    }
-
-    /// Share some precalculated values between threads to boost the performance
-    fn setup_pq_omegas(&mut self, omega: &E::Fr, n: usize, max_deg: u32) -> GPUResult<()> {
-        // Precalculate:
-        // [omega^(0/(2^(deg-1))), omega^(1/(2^(deg-1))), ..., omega^((2^(deg-1)-1)/(2^(deg-1)))]
-        let mut pq = vec![E::Fr::zero(); 1 << max_deg >> 1];
-        let twiddle = omega.pow_vartime([(n >> max_deg) as u64]);
-        pq[0] = E::Fr::one();
-        if max_deg > 1 {
-            pq[1] = twiddle;
-            for i in 2..(1 << max_deg >> 1) {
-                pq[i] = pq[i - 1];
-                pq[i].mul_assign(&twiddle);
-            }
-        }
-        self.program.write_from_buffer(&self.pq_buffer, 0, &pq)?;
-
-        // Precalculate [omega, omega^2, omega^4, omega^8, ..., omega^(2^31)]
-        let mut omegas = vec![E::Fr::zero(); 32];
-        omegas[0] = *omega;
-        for i in 1..LOG2_MAX_ELEMENTS {
-            omegas[i] = omegas[i - 1].pow_vartime([2u64]);
-        }
-        self.program
-            .write_from_buffer(&self.omegas_buffer, 0, &omegas)?;
-
-        Ok(())
-    }
-
-    /// Performs FFT on `a`
+    /// Performs FFT on `input`
     /// * `omega` - Special value `omega` is used for FFT over finite-fields
     /// * `log_n` - Specifies log2 of number of elements
-    pub fn radix_fft(&mut self, a: &mut [E::Fr], omega: &E::Fr, log_n: u32) -> GPUResult<()> {
-        let n = 1 << log_n;
-        let mut src_buffer = self.program.create_buffer::<E::Fr>(n)?;
-        let mut dst_buffer = self.program.create_buffer::<E::Fr>(n)?;
+    pub fn radix_fft(&mut self, input: &mut [E::Fr], omega: &E::Fr, log_n: u32) -> GPUResult<()> {
+        let closures = program_closures!(|program, input: &mut [E::Fr]| -> GPUResult<()> {
+            let n = 1 << log_n;
+            // All usages are safe as the buffers are initialized from either the host or the GPU
+            // before they are read.
+            let mut src_buffer = unsafe { program.create_buffer::<E::Fr>(n)? };
+            let mut dst_buffer = unsafe { program.create_buffer::<E::Fr>(n)? };
+            // The precalculated values pq` and `omegas` are valid for radix degrees up to `max_deg`
+            let max_deg = cmp::min(MAX_LOG2_RADIX, log_n);
 
-        let max_deg = cmp::min(MAX_LOG2_RADIX, log_n);
-        self.setup_pq_omegas(omega, n, max_deg)?;
+            // Precalculate:
+            // [omega^(0/(2^(deg-1))), omega^(1/(2^(deg-1))), ..., omega^((2^(deg-1)-1)/(2^(deg-1)))]
+            let mut pq = vec![E::Fr::zero(); 1 << max_deg >> 1];
+            let twiddle = omega.pow_vartime([(n >> max_deg) as u64]);
+            pq[0] = E::Fr::one();
+            if max_deg > 1 {
+                pq[1] = twiddle;
+                for i in 2..(1 << max_deg >> 1) {
+                    pq[i] = pq[i - 1];
+                    pq[i].mul_assign(&twiddle);
+                }
+            }
+            let pq_buffer = program.create_buffer_from_slice(&pq)?;
 
-        self.program.write_from_buffer(&src_buffer, 0, &*a)?;
-        let mut log_p = 0u32;
-        while log_p < log_n {
-            let deg = cmp::min(max_deg, log_n - log_p);
-            self.radix_fft_round(&src_buffer, &dst_buffer, log_n, log_p, deg, max_deg)?;
-            log_p += deg;
-            std::mem::swap(&mut src_buffer, &mut dst_buffer);
-        }
+            // Precalculate [omega, omega^2, omega^4, omega^8, ..., omega^(2^31)]
+            let mut omegas = vec![E::Fr::zero(); 32];
+            omegas[0] = *omega;
+            for i in 1..LOG2_MAX_ELEMENTS {
+                omegas[i] = omegas[i - 1].pow_vartime([2u64]);
+            }
+            let omegas_buffer = program.create_buffer_from_slice(&omegas)?;
 
-        self.program.read_into_buffer(&src_buffer, 0, a)?;
+            program.write_from_buffer(&mut src_buffer, &*input)?;
+            // Specifies log2 of `p`, (http://www.bealto.com/gpu-fft_group-1.html)
+            let mut log_p = 0u32;
+            // Each iteration performs a FFT round
+            while log_p < log_n {
+                // 1=>radix2, 2=>radix4, 3=>radix8, ...
+                let deg = cmp::min(max_deg, log_n - log_p);
 
-        Ok(())
+                if locks::PriorityLock::should_break(self.priority) {
+                    return Err(GPUError::GPUTaken);
+                }
+
+                let n = 1u32 << log_n;
+                let local_work_size = 1 << cmp::min(deg - 1, MAX_LOG2_LOCAL_WORK_SIZE);
+                let global_work_size = n >> deg;
+                let kernel = program.create_kernel(
+                    "radix_fft",
+                    global_work_size as usize,
+                    local_work_size as usize,
+                )?;
+                kernel
+                    .arg(&src_buffer)
+                    .arg(&dst_buffer)
+                    .arg(&pq_buffer)
+                    .arg(&omegas_buffer)
+                    .arg(&LocalBuffer::<E::Fr>::new(1 << deg))
+                    .arg(&n)
+                    .arg(&log_p)
+                    .arg(&deg)
+                    .arg(&max_deg)
+                    .run()?;
+
+                log_p += deg;
+                std::mem::swap(&mut src_buffer, &mut dst_buffer);
+            }
+
+            program.read_into_buffer(&src_buffer, input)?;
+
+            Ok(())
+        });
+
+        self.program.run(closures, input)
     }
 }

--- a/src/gpu/fft/fft.cl
+++ b/src/gpu/fft/fft.cl
@@ -1,4 +1,4 @@
-uint bitreverse(uint n, uint bits) {
+DEVICE uint bitreverse(uint n, uint bits) {
   uint r = 0;
   for(int i = 0; i < bits; i++) {
     r = (r << 1) | (n & 1);
@@ -10,19 +10,27 @@ uint bitreverse(uint n, uint bits) {
 /*
  * FFT algorithm is inspired from: http://www.bealto.com/gpu-fft_group-1.html
  */
-__kernel void radix_fft(__global FIELD* x, // Source buffer
-                        __global FIELD* y, // Destination buffer
-                        __global FIELD* pq, // Precalculated twiddle factors
-                        __global FIELD* omegas, // [omega, omega^2, omega^4, ...]
-                        __local FIELD* u, // Local buffer to store intermediary values
-                        uint n, // Number of elements
-                        uint lgp, // Log2 of `p` (Read more in the link above)
-                        uint deg, // 1=>radix2, 2=>radix4, 3=>radix8, ...
-                        uint max_deg) // Maximum degree supported, according to `pq` and `omegas`
+KERNEL void radix_fft(GLOBAL FIELD* x, // Source buffer
+                      GLOBAL FIELD* y, // Destination buffer
+                      GLOBAL FIELD* pq, // Precalculated twiddle factors
+                      GLOBAL FIELD* omegas, // [omega, omega^2, omega^4, ...]
+                      LOCAL FIELD* u_arg, // Local buffer to store intermediary values
+                      uint n, // Number of elements
+                      uint lgp, // Log2 of `p` (Read more in the link above)
+                      uint deg, // 1=>radix2, 2=>radix4, 3=>radix8, ...
+                      uint max_deg) // Maximum degree supported, according to `pq` and `omegas`
 {
-  uint lid = get_local_id(0);
-  uint lsize = get_local_size(0);
-  uint index = get_group_id(0);
+// CUDA doesn't support local buffers ("shared memory" in CUDA lingo) as function arguments,
+// ignore that argument and declare the external memory here instead.
+#ifdef CUDA
+  extern LOCAL FIELD u[];
+#else
+   LOCAL FIELD* u = u_arg;
+#endif
+
+  uint lid = GET_LOCAL_ID();
+  uint lsize = GET_LOCAL_SIZE();
+  uint index = GET_GROUP_ID();
   uint t = n >> deg;
   uint p = 1 << lgp;
   uint k = index & (p - 1);
@@ -43,7 +51,7 @@ __kernel void radix_fft(__global FIELD* x, // Source buffer
     u[i] = FIELD_mul(tmp, x[i*t]);
     tmp = FIELD_mul(tmp, twiddle);
   }
-  barrier(CLK_LOCAL_MEM_FENCE);
+  BARRIER_LOCAL();
 
   const uint pqshift = max_deg - deg;
   for(uint rnd = 0; rnd < deg; rnd++) {
@@ -58,7 +66,7 @@ __kernel void radix_fft(__global FIELD* x, // Source buffer
       if(di != 0) u[i1] = FIELD_mul(pq[di << rnd << pqshift], u[i1]);
     }
 
-    barrier(CLK_LOCAL_MEM_FENCE);
+    BARRIER_LOCAL();
   }
 
   for(uint i = counts >> 1; i < counte >> 1; i++) {
@@ -68,9 +76,9 @@ __kernel void radix_fft(__global FIELD* x, // Source buffer
 }
 
 /// Multiplies all of the elements by `field`
-__kernel void mul_by_field(__global FIELD* elements,
+KERNEL void mul_by_field(GLOBAL FIELD* elements,
                         uint n,
                         FIELD field) {
-  const uint gid = get_global_id(0);
+  const uint gid = GET_GLOBAL_ID();
   elements[gid] = FIELD_mul(elements[gid], field);
 }

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -2,45 +2,48 @@ mod error;
 
 pub use self::error::*;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 mod locks;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 pub use self::locks::*;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
+mod program;
+
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 mod sources;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 pub use self::sources::*;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 mod utils;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 pub use self::utils::*;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 mod fft;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 pub use self::fft::*;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 mod multiexp;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 pub use self::multiexp::*;
 
-#[cfg(not(feature = "gpu"))]
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
 mod nogpu;
 
-#[cfg(not(feature = "gpu"))]
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
 pub use self::nogpu::*;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 pub use ec_gpu::GpuEngine;
-#[cfg(not(feature = "gpu"))]
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
 pub trait GpuEngine {}
-#[cfg(not(feature = "gpu"))]
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
 impl<E: pairing::Engine> GpuEngine for E {}

--- a/src/gpu/multiexp/multiexp.cl
+++ b/src/gpu/multiexp/multiexp.cl
@@ -8,18 +8,18 @@
  * threads running in parallel for calculating a multiexp instance.
  */
 
-__kernel void POINT_bellman_multiexp(
-    __global POINT_affine *bases,
-    __global POINT_projective *buckets,
-    __global POINT_projective *results,
-    __global EXPONENT *exps,
+KERNEL void POINT_bellman_multiexp(
+    GLOBAL POINT_affine *bases,
+    GLOBAL POINT_projective *buckets,
+    GLOBAL POINT_projective *results,
+    GLOBAL EXPONENT *exps,
     uint n,
     uint num_groups,
     uint num_windows,
     uint window_size) {
 
   // We have `num_windows` * `num_groups` threads per multiexp.
-  const uint gid = get_global_id(0);
+  const uint gid = GET_GLOBAL_ID();
   if(gid >= num_windows * num_groups) return;
 
   // We have (2^window_size - 1) buckets.
@@ -44,7 +44,7 @@ __kernel void POINT_bellman_multiexp(
   for(uint i = nstart; i < nend; i++) {
     uint ind = EXPONENT_get_bits(exps[i], bits, w);
 
-    #ifdef NVIDIA
+    #if defined(OPENCL_NVIDIA) || defined(CUDA)
       // O_o, weird optimization, having a single special case makes it
       // tremendously faster!
       // 511 is chosen because it's half of the maximum bucket len, but

--- a/src/gpu/program.rs
+++ b/src/gpu/program.rs
@@ -1,0 +1,80 @@
+use std::env;
+
+#[cfg(feature = "opencl")]
+use ec_gpu_gen::Limb64;
+use log::info;
+#[cfg(feature = "cuda")]
+use rust_gpu_tools::cuda;
+#[cfg(feature = "opencl")]
+use rust_gpu_tools::opencl;
+use rust_gpu_tools::{Device, Framework, GPUError as GpuToolsError, Program};
+
+#[cfg(not(all(feature = "cuda", feature = "opencl")))]
+use crate::gpu::error::GPUError;
+use crate::gpu::error::GPUResult;
+#[cfg(feature = "opencl")]
+use crate::gpu::sources;
+use crate::gpu::GpuEngine;
+use pairing::Engine;
+
+/// Returns the program for the preferred [`rust_gpu_tools::device::Framework`].
+///
+/// If the device supports CUDA, then CUDA is used, else OpenCL. You can force a selection with
+/// the environment variable `BELLMAN_GPU_FRAMEWORK`, which can be set either to `cuda` or `opencl`.
+pub fn program<E>(device: &Device) -> GPUResult<Program>
+where
+    E: Engine + GpuEngine,
+{
+    let framework = match env::var("BELLMAN_GPU_FRAMEWORK") {
+        Ok(env) => match env.as_ref() {
+            "cuda" => {
+                #[cfg(feature = "cuda")]
+                {
+                    Framework::Cuda
+                }
+
+                #[cfg(not(feature = "cuda"))]
+                return Err(GPUError::Simple("CUDA framework is not supported, please compile with the `cuda` feature enabled."));
+            }
+            "opencl" => {
+                #[cfg(feature = "opencl")]
+                {
+                    Framework::Opencl
+                }
+
+                #[cfg(not(feature = "opencl"))]
+                return Err(GPUError::Simple("OpenCL framework is not supported, please compile with the `opencl` feature enabled."));
+            }
+            _ => device.framework(),
+        },
+        Err(_) => device.framework(),
+    };
+    program_use_framework::<E>(device, &framework)
+}
+
+/// Returns the program for the specified [`rust_gpu_tools::device::Framework`].
+pub fn program_use_framework<E>(device: &Device, framework: &Framework) -> GPUResult<Program>
+where
+    E: Engine + GpuEngine,
+{
+    match framework {
+        #[cfg(feature = "cuda")]
+        Framework::Cuda => {
+            info!("Using kernel on CUDA.");
+            let kernel = include_bytes!(env!("CUDA_MULTIEXP_FATBIN"));
+            let cuda_device = device.cuda_device().ok_or(GpuToolsError::DeviceNotFound)?;
+            let program = cuda::Program::from_bytes(cuda_device, kernel)?;
+            Ok(Program::Cuda(program))
+        }
+        #[cfg(feature = "opencl")]
+        Framework::Opencl => {
+            info!("Using kernel on OpenCL.");
+            let src = sources::kernel::<E, Limb64>();
+            let opencl_device = device
+                .opencl_device()
+                .ok_or(GpuToolsError::DeviceNotFound)?;
+            let program = opencl::Program::from_opencl(opencl_device, &src)?;
+            Ok(Program::Opencl(program))
+        }
+    }
+}

--- a/src/gpu/program.rs
+++ b/src/gpu/program.rs
@@ -17,6 +17,38 @@ use crate::gpu::sources;
 use crate::gpu::GpuEngine;
 use pairing::Engine;
 
+/// Selects a CUDA or OpenCL on the `BELLMAN_GPU_FRAMEWORK` environment variable and the
+/// compile-time features.
+///
+/// You cannot select CUDA if the library was compiled without support for it.
+#[allow(clippy::unnecessary_wraps)] // No error can be returned if `cuda` and `opencl `are enabled.
+fn select_framework(default_framework: Framework) -> GPUResult<Framework> {
+    match env::var("BELLMAN_GPU_FRAMEWORK") {
+        Ok(env) => match env.as_ref() {
+            "cuda" => {
+                #[cfg(feature = "cuda")]
+                {
+                    Ok(Framework::Cuda)
+                }
+
+                #[cfg(not(feature = "cuda"))]
+                Err(GPUError::Simple("CUDA framework is not supported, please compile with the `cuda` feature enabled."))
+            }
+            "opencl" => {
+                #[cfg(feature = "opencl")]
+                {
+                    Ok(Framework::Opencl)
+                }
+
+                #[cfg(not(feature = "opencl"))]
+                Err(GPUError::Simple("OpenCL framework is not supported, please compile with the `opencl` feature enabled."))
+            }
+            _ => Ok(default_framework),
+        },
+        Err(_) => Ok(default_framework),
+    }
+}
+
 /// Returns the program for the preferred [`rust_gpu_tools::device::Framework`].
 ///
 /// If the device supports CUDA, then CUDA is used, else OpenCL. You can force a selection with
@@ -25,30 +57,7 @@ pub fn program<E>(device: &Device) -> GPUResult<Program>
 where
     E: Engine + GpuEngine,
 {
-    let framework = match env::var("BELLMAN_GPU_FRAMEWORK") {
-        Ok(env) => match env.as_ref() {
-            "cuda" => {
-                #[cfg(feature = "cuda")]
-                {
-                    Framework::Cuda
-                }
-
-                #[cfg(not(feature = "cuda"))]
-                return Err(GPUError::Simple("CUDA framework is not supported, please compile with the `cuda` feature enabled."));
-            }
-            "opencl" => {
-                #[cfg(feature = "opencl")]
-                {
-                    Framework::Opencl
-                }
-
-                #[cfg(not(feature = "opencl"))]
-                return Err(GPUError::Simple("OpenCL framework is not supported, please compile with the `opencl` feature enabled."));
-            }
-            _ => device.framework(),
-        },
-        Err(_) => device.framework(),
-    };
+    let framework = select_framework(device.framework())?;
     program_use_framework::<E>(device, &framework)
 }
 
@@ -75,6 +84,84 @@ where
                 .ok_or(GpuToolsError::DeviceNotFound)?;
             let program = opencl::Program::from_opencl(opencl_device, &src)?;
             Ok(Program::Opencl(program))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils;
+
+    use super::*;
+
+    #[test]
+    fn test_bellman_gpu_framework() {
+        #[cfg(all(feature = "cuda", feature = "opencl"))]
+        {
+            // Use CUDA if set
+            test_utils::with_env_vars(vec![("BELLMAN_GPU_FRAMEWORK", Some("cuda"))], || {
+                assert_eq!(
+                    select_framework(Framework::Opencl).unwrap(),
+                    Framework::Cuda
+                );
+            });
+
+            // Use OpenCL if set
+            test_utils::with_env_vars(vec![("BELLMAN_GPU_FRAMEWORK", Some("opencl"))], || {
+                assert_eq!(
+                    select_framework(Framework::Cuda).unwrap(),
+                    Framework::Opencl
+                );
+            });
+
+            // Use default framework if arbitrary value is set
+            test_utils::with_env_vars(vec![("BELLMAN_GPU_FRAMEWORK", None)], || {
+                assert_eq!(select_framework(Framework::Cuda).unwrap(), Framework::Cuda);
+            });
+            test_utils::with_env_vars(vec![("BELLMAN_GPU_FRAMEWORK", None)], || {
+                assert_eq!(
+                    select_framework(Framework::Opencl).unwrap(),
+                    Framework::Opencl
+                );
+            });
+        }
+
+        #[cfg(feature = "cuda")]
+        {
+            // Use default value if no value is set
+            test_utils::with_env_vars(vec![("BELLMAN_GPU_FRAMEWORK", None)], || {
+                assert_eq!(select_framework(Framework::Cuda).unwrap(), Framework::Cuda);
+            });
+
+            // Use default framework if arbitrary value is set
+            test_utils::with_env_vars(
+                vec![("BELLMAN_GPU_FRAMEWORK", Some("notcudaoropencl"))],
+                || {
+                    assert_eq!(select_framework(Framework::Cuda).unwrap(), Framework::Cuda);
+                },
+            );
+        }
+
+        #[cfg(feature = "opencl")]
+        {
+            // Use default value if no value is set
+            test_utils::with_env_vars(vec![("BELLMAN_GPU_FRAMEWORK", None)], || {
+                assert_eq!(
+                    select_framework(Framework::Opencl).unwrap(),
+                    Framework::Opencl
+                );
+            });
+
+            // Use default framework if arbitrary value is set
+            test_utils::with_env_vars(
+                vec![("BELLMAN_GPU_FRAMEWORK", Some("notcudaoropencl"))],
+                || {
+                    assert_eq!(
+                        select_framework(Framework::Opencl).unwrap(),
+                        Framework::Opencl
+                    );
+                },
+            );
         }
     }
 }

--- a/src/gpu/sources.rs
+++ b/src/gpu/sources.rs
@@ -1,8 +1,9 @@
-use super::GpuEngine;
+use ec_gpu::GpuEngine;
+use ec_gpu_gen::Limb;
 
 // Instead of having a very large OpenCL program written for a specific curve, with a lot of
 // rudandant codes (As OpenCL doesn't have generic types or templates), this module will dynamically
-// generate OpenCL codes given different PrimeFields and curves.
+// generate CUDA/OpenCL codes given different PrimeFields and curves.
 
 static FFT_SRC: &str = include_str!("fft/fft.cl");
 static MULTIEXP_SRC: &str = include_str!("multiexp/multiexp.cl");
@@ -18,12 +19,14 @@ fn multiexp(point: &str, exp: &str) -> String {
 }
 
 // WARNING: This function works only with Short Weierstrass Jacobian curves with Fq2 extension field.
-pub fn kernel<E>(limb64: bool) -> String
+pub fn kernel<E, L>() -> String
 where
     E: GpuEngine,
+    L: Limb,
 {
     [
-        ec_gpu_gen::gen_ec_source::<E>(limb64),
+        ec_gpu_gen::common(),
+        ec_gpu_gen::gen_ec_source::<E, L>(),
         fft("Fr"),
         multiexp("G1", "Fr"),
         multiexp("G2", "Fr"),

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -1,5 +1,5 @@
 use log::{info, warn};
-use rust_gpu_tools::*;
+use rust_gpu_tools::Device;
 use std::collections::HashMap;
 use std::env;
 
@@ -56,9 +56,8 @@ lazy_static::lazy_static! {
 }
 
 const DEFAULT_CORE_COUNT: usize = 2560;
-pub fn get_core_count(d: &opencl::Device) -> usize {
-    let name = d.name();
-    match CORE_COUNTS.get(&name[..]) {
+pub fn get_core_count(name: &str) -> usize {
+    match CORE_COUNTS.get(name) {
         Some(&cores) => cores,
         None => {
             warn!(
@@ -74,12 +73,12 @@ pub fn get_core_count(d: &opencl::Device) -> usize {
 }
 
 pub fn dump_device_list() {
-    for d in opencl::Device::all() {
+    for d in Device::all() {
         info!("Device: {:?}", d);
     }
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 #[test]
 pub fn test_list_devices() {
     let _ = env_logger::try_init();

--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -4,7 +4,7 @@
 
 // The `DummyEngine` currently only works on the CPU as G1/G2 is using `Fr` and `Fr` isn't
 // supported by the GPU kernels
-#[cfg(all(test, not(feature = "gpu")))]
+#[cfg(all(test, not(any(feature = "cuda", feature = "opencl"))))]
 mod tests;
 
 pub mod aggregate;

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -17,10 +17,10 @@ use crate::{
     Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable, BELLMAN_VERSION,
 };
 use log::info;
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 use log::trace;
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 use crate::gpu::PriorityLock;
 
 fn eval<E: Engine>(
@@ -302,7 +302,7 @@ where
         log_d += 1;
     }
 
-    #[cfg(feature = "gpu")]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     let prio_lock = if priority {
         trace!("acquiring priority lock");
         Some(PriorityLock::lock())
@@ -512,7 +512,7 @@ where
         )
         .collect::<Result<Vec<_>, SynthesisError>>()?;
 
-    #[cfg(feature = "gpu")]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     {
         trace!("dropping priority lock");
         drop(prio_lock);

--- a/src/groth16/tests/dummy_engine.rs
+++ b/src/groth16/tests/dummy_engine.rs
@@ -17,7 +17,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 const MODULUS_R: Wrapping<u32> = Wrapping(64513);
 const R: u32 = 1;
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 const R2: u32 = 1;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -358,13 +358,13 @@ impl Engine for DummyEngine {
     }
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 impl ec_gpu::GpuEngine for DummyEngine {
     type Scalar = Fr;
     type Fp = Fr;
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 impl ec_gpu::GpuField for Fr {
     fn one() -> Vec<u32> {
         vec![R]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,10 @@ pub mod gpu;
 pub mod groth16;
 pub mod multicore;
 pub mod multiexp;
-
+#[cfg(test)]
+pub mod test_utils;
 pub mod util_cs;
+
 use ff::Field;
 
 use pairing::Engine;

--- a/src/multicore.rs
+++ b/src/multicore.rs
@@ -126,59 +126,10 @@ fn log2_floor(num: usize) -> u32 {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::env::{self, VarError};
-    use std::panic::{self, RefUnwindSafe, UnwindSafe};
-    use std::sync::Mutex;
+pub mod tests {
+    use crate::test_utils;
 
     use super::*;
-
-    lazy_static! {
-        static ref SERIAL_TEST: Mutex<()> = Default::default();
-    }
-
-    /// Sets environment variables to the given value for the duration of the closure.
-    /// Restores the previous values when the closure completes or panics, before unwinding the panic.
-    pub fn with_env_vars<F>(kvs: Vec<(&str, Option<&str>)>, closure: F)
-    where
-        F: Fn() + UnwindSafe + RefUnwindSafe,
-    {
-        let guard = SERIAL_TEST.lock().unwrap();
-        let mut old_kvs: Vec<(&str, Result<String, VarError>)> = Vec::new();
-        for (k, v) in kvs {
-            let old_v = env::var(k);
-            old_kvs.push((k, old_v));
-            match v {
-                None => env::remove_var(k),
-                Some(v) => env::set_var(k, v),
-            }
-        }
-
-        match panic::catch_unwind(|| {
-            closure();
-        }) {
-            Ok(_) => {
-                for (k, v) in old_kvs {
-                    reset_env(k, v);
-                }
-            }
-            Err(err) => {
-                for (k, v) in old_kvs {
-                    reset_env(k, v);
-                }
-                drop(guard);
-                panic::resume_unwind(err);
-            }
-        };
-    }
-
-    fn reset_env(k: &str, old: Result<String, VarError>) {
-        if let Ok(v) = old {
-            env::set_var(k, v);
-        } else {
-            env::remove_var(k);
-        }
-    }
 
     #[test]
     fn test_log2_floor() {
@@ -194,7 +145,7 @@ mod tests {
     #[test]
     fn test_read_num_cpus() {
         // use bellman if set
-        with_env_vars(
+        test_utils::with_env_vars(
             vec![("BELLMAN_NUM_CPUS", Some("6")), ("RAYON_NUM_THREADS", None)],
             || {
                 assert_eq!(read_num_cpus(), 6);
@@ -202,7 +153,7 @@ mod tests {
         );
 
         // bellman has priority over rayon
-        with_env_vars(
+        test_utils::with_env_vars(
             vec![
                 ("BELLMAN_NUM_CPUS", Some("6")),
                 ("RAYON_NUM_THREADS", Some("7")),
@@ -213,7 +164,7 @@ mod tests {
         );
 
         // use rayon if set, if bellman is not
-        with_env_vars(
+        test_utils::with_env_vars(
             vec![("BELLMAN_NUM_CPUS", None), ("RAYON_NUM_THREADS", Some("7"))],
             || {
                 assert_eq!(read_num_cpus(), 7);
@@ -221,7 +172,7 @@ mod tests {
         );
 
         // use num cpus if none is set
-        with_env_vars(
+        test_utils::with_env_vars(
             vec![("BELLMAN_NUM_CPUS", None), ("RAYON_NUM_THREADS", None)],
             || {
                 assert_eq!(read_num_cpus(), num_cpus::get());

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -369,7 +369,7 @@ where
 
     #[allow(clippy::let_and_return)]
     let result = pool.compute(move || multiexp_inner(bases, density_map, exponents, c));
-    #[cfg(feature = "gpu")]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     {
         // Do not give the control back to the caller till the
         // multiexp is done. We may want to reacquire the GPU again
@@ -377,7 +377,7 @@ where
         let result = result.wait();
         Waiter::done(result)
     }
-    #[cfg(not(feature = "gpu"))]
+    #[cfg(not(any(feature = "cuda", feature = "opencl")))]
     result
 }
 
@@ -446,7 +446,7 @@ where
     }
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 #[test]
 pub fn gpu_multiexp_consistency() {
     use blstrs::Bls12;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,52 @@
+use std::env::{self, VarError};
+use std::panic::{self, RefUnwindSafe, UnwindSafe};
+use std::sync::Mutex;
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref SERIAL_TEST: Mutex<()> = Default::default();
+}
+
+/// Sets environment variables to the given value for the duration of the closure.
+/// Restores the previous values when the closure completes or panics, before unwinding the panic.
+pub fn with_env_vars<F>(kvs: Vec<(&str, Option<&str>)>, closure: F)
+where
+    F: Fn() + UnwindSafe + RefUnwindSafe,
+{
+    let guard = SERIAL_TEST.lock().unwrap();
+    let mut old_kvs: Vec<(&str, Result<String, VarError>)> = Vec::new();
+    for (k, v) in kvs {
+        let old_v = env::var(k);
+        old_kvs.push((k, old_v));
+        match v {
+            None => env::remove_var(k),
+            Some(v) => env::set_var(k, v),
+        }
+    }
+
+    match panic::catch_unwind(|| {
+        closure();
+    }) {
+        Ok(_) => {
+            for (k, v) in old_kvs {
+                reset_env(k, v);
+            }
+        }
+        Err(err) => {
+            for (k, v) in old_kvs {
+                reset_env(k, v);
+            }
+            drop(guard);
+            panic::resume_unwind(err);
+        }
+    };
+}
+
+fn reset_env(k: &str, old: Result<String, VarError>) {
+    if let Ok(v) = old {
+        env::set_var(k, v);
+    } else {
+        env::remove_var(k);
+    }
+}

--- a/tests/gpu_provers.rs
+++ b/tests/gpu_provers.rs
@@ -36,7 +36,7 @@ impl<E: Engine> Circuit<E> for DummyDemo {
     }
 }
 
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "cuda", feature = "opencl"))]
 #[test]
 pub fn test_parallel_prover() {
     use bellperson::groth16::{

--- a/verifier-bench/Cargo.toml
+++ b/verifier-bench/Cargo.toml
@@ -19,5 +19,6 @@ blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master"
 
 [features]
 default = ["groth16"]
-gpu = ["bellperson/gpu", "blstrs/gpu"]
+cuda = ["bellperson/cuda", "blstrs/gpu"]
+opencl = ["bellperson/opencl", "blstrs/gpu"]
 groth16 = ["bellperson/groth16"]


### PR DESCRIPTION
A new environment variable `BELLMAN_GPU_FRAMEWORK` is introduced to select
CUDA or OpenCL if Bellperson is compiled with support for both.

Currently only the multiexp calculation is supported by CUDA, the FFT
calculation still runs on OpenCL.

BREAKING CHANGE: `gpu` feature is replaced with `cuda` and `opencl` feature.

The `gpu` feature is now split into two pieces, `opencl` and `cuda`, you can
compile the library with either or both.