### PR TITLE
refactor: remove `Group` abstraction in domain

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -11,10 +11,7 @@
 //! [`EvaluationDomain`]: crate::domain::EvaluationDomain
 //! [Groth16]: https://eprint.iacr.org/2016/260
 
-use std::ops::{AddAssign, MulAssign, SubAssign};
-
 use ff::{Field, PrimeField};
-use group::Curve;
 use pairing::Engine;
 
 use super::multicore::Worker;
@@ -23,8 +20,8 @@ use crate::gpu;
 
 use log::{info, warn};
 
-pub struct EvaluationDomain<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> {
-    coeffs: Vec<G>,
+pub struct EvaluationDomain<E: Engine + gpu::GpuEngine> {
+    coeffs: Vec<E::Fr>,
     exp: u32,
     omega: E::Fr,
     omegainv: E::Fr,
@@ -32,24 +29,24 @@ pub struct EvaluationDomain<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> {
     minv: E::Fr,
 }
 
-impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> AsRef<[G]> for EvaluationDomain<E, G> {
-    fn as_ref(&self) -> &[G] {
+impl<E: Engine + gpu::GpuEngine> AsRef<[E::Fr]> for EvaluationDomain<E> {
+    fn as_ref(&self) -> &[E::Fr] {
         &self.coeffs
     }
 }
 
-impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> AsMut<[G]> for EvaluationDomain<E, G> {
-    fn as_mut(&mut self) -> &mut [G] {
+impl<E: Engine + gpu::GpuEngine> AsMut<[E::Fr]> for EvaluationDomain<E> {
+    fn as_mut(&mut self) -> &mut [E::Fr] {
         &mut self.coeffs
     }
 }
 
-impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
-    pub fn into_coeffs(self) -> Vec<G> {
+impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
+    pub fn into_coeffs(self) -> Vec<E::Fr> {
         self.coeffs
     }
 
-    pub fn from_coeffs(mut coeffs: Vec<G>) -> Result<EvaluationDomain<E, G>, SynthesisError> {
+    pub fn from_coeffs(mut coeffs: Vec<E::Fr>) -> Result<EvaluationDomain<E>, SynthesisError> {
         // Compute the size of our evaluation domain
         let mut m = 1;
         let mut exp = 0;
@@ -70,7 +67,7 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
         }
 
         // Extend the coeffs vector with zeroes if necessary
-        coeffs.resize(m, G::group_zero());
+        coeffs.resize(m, E::Fr::zero());
 
         Ok(EvaluationDomain {
             coeffs,
@@ -104,7 +101,7 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
             for v in self.coeffs.chunks_mut(chunk) {
                 scope.execute(move || {
                     for v in v {
-                        v.group_mul_assign(&minv);
+                        *v *= minv;
                     }
                 });
             }
@@ -119,8 +116,8 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
                 scope.execute(move || {
                     let mut u = g.pow_vartime(&[(i * chunk) as u64]);
                     for v in v.iter_mut() {
-                        v.group_mul_assign(&u);
-                        u.mul_assign(&g);
+                        *v *= u;
+                        u *= g;
                     }
                 });
             }
@@ -151,10 +148,8 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
     /// This evaluates t(tau) for this domain, which is
     /// tau^m - 1 for these radix-2 domains.
     pub fn z(&self, tau: &E::Fr) -> E::Fr {
-        let mut tmp = tau.pow_vartime(&[self.coeffs.len() as u64]);
-        tmp.sub_assign(&E::Fr::one());
-
-        tmp
+        let tmp = tau.pow_vartime(&[self.coeffs.len() as u64]);
+        tmp - E::Fr::one()
     }
 
     /// The target polynomial is the zero polynomial in our
@@ -167,7 +162,7 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
             for v in self.coeffs.chunks_mut(chunk) {
                 scope.execute(move || {
                     for v in v {
-                        v.group_mul_assign(&i);
+                        *v *= i;
                     }
                 });
             }
@@ -175,7 +170,7 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
     }
 
     /// Perform O(n) multiplication of two polynomials in the domain.
-    pub fn mul_assign(&mut self, worker: &Worker, other: &EvaluationDomain<E, Scalar<E>>) {
+    pub fn mul_assign(&mut self, worker: &Worker, other: &EvaluationDomain<E>) {
         assert_eq!(self.coeffs.len(), other.coeffs.len());
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
@@ -186,7 +181,7 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
             {
                 scope.execute(move || {
                     for (a, b) in a.iter_mut().zip(b.iter()) {
-                        a.group_mul_assign(&b.0);
+                        *a *= b;
                     }
                 });
             }
@@ -194,7 +189,7 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
     }
 
     /// Perform O(n) subtraction of one polynomial from another in the domain.
-    pub fn sub_assign(&mut self, worker: &Worker, other: &EvaluationDomain<E, G>) {
+    pub fn sub_assign(&mut self, worker: &Worker, other: &EvaluationDomain<E>) {
         assert_eq!(self.coeffs.len(), other.coeffs.len());
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
@@ -205,7 +200,7 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
             {
                 scope.execute(move || {
                     for (a, b) in a.iter_mut().zip(b.iter()) {
-                        a.group_sub_assign(&b);
+                        *a -= b;
                     }
                 });
             }
@@ -213,78 +208,9 @@ impl<E: Engine + gpu::GpuEngine, G: Group<E::Fr>> EvaluationDomain<E, G> {
     }
 }
 
-pub trait Group<S: PrimeField>: Sized + Copy + Clone + Send + Sync {
-    fn group_zero() -> Self;
-    fn group_mul_assign(&mut self, by: &S);
-    fn group_add_assign(&mut self, other: &Self);
-    fn group_sub_assign(&mut self, other: &Self);
-}
-
-pub struct Point<G: Curve>(pub G);
-
-impl<G: Curve> PartialEq for Point<G> {
-    fn eq(&self, other: &Point<G>) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<G: Curve> Copy for Point<G> {}
-
-impl<G: Curve> Clone for Point<G> {
-    fn clone(&self) -> Point<G> {
-        *self
-    }
-}
-
-impl<G: Curve> Group<G::Scalar> for Point<G> {
-    fn group_zero() -> Self {
-        Point(G::identity())
-    }
-    fn group_mul_assign(&mut self, by: &G::Scalar) {
-        self.0.mul_assign(by);
-    }
-    fn group_add_assign(&mut self, other: &Self) {
-        self.0.add_assign(&other.0);
-    }
-    fn group_sub_assign(&mut self, other: &Self) {
-        self.0.sub_assign(&other.0);
-    }
-}
-
-pub struct Scalar<E: Engine>(pub E::Fr);
-
-impl<E: Engine> PartialEq for Scalar<E> {
-    fn eq(&self, other: &Scalar<E>) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl<E: Engine> Copy for Scalar<E> {}
-
-impl<E: Engine> Clone for Scalar<E> {
-    fn clone(&self) -> Scalar<E> {
-        *self
-    }
-}
-
-impl<E: Engine> Group<E::Fr> for Scalar<E> {
-    fn group_zero() -> Self {
-        Scalar(E::Fr::zero())
-    }
-    fn group_mul_assign(&mut self, by: &E::Fr) {
-        self.0.mul_assign(by);
-    }
-    fn group_add_assign(&mut self, other: &Self) {
-        self.0.add_assign(&other.0);
-    }
-    fn group_sub_assign(&mut self, other: &Self) {
-        self.0.sub_assign(&other.0);
-    }
-}
-
-fn best_fft<E: Engine + gpu::GpuEngine, T: Group<E::Fr>>(
+fn best_fft<E: Engine + gpu::GpuEngine>(
     kern: &mut Option<gpu::LockedFFTKernel<E>>,
-    a: &mut [T],
+    a: &mut [E::Fr],
     worker: &Worker,
     omega: &E::Fr,
     log_n: u32,
@@ -300,32 +226,24 @@ fn best_fft<E: Engine + gpu::GpuEngine, T: Group<E::Fr>>(
 
     let log_cpus = worker.log_num_cpus();
     if log_n <= log_cpus {
-        serial_fft::<E, T>(a, omega, log_n);
+        serial_fft::<E>(a, omega, log_n);
     } else {
-        parallel_fft::<E, T>(a, worker, omega, log_n, log_cpus);
+        parallel_fft::<E>(a, worker, omega, log_n, log_cpus);
     }
 }
 
-pub fn gpu_fft<E: Engine + gpu::GpuEngine, T: Group<E::Fr>>(
+pub fn gpu_fft<E: Engine + gpu::GpuEngine>(
     kern: &mut gpu::FFTKernel<E>,
-    a: &mut [T],
+    a: &mut [E::Fr],
     omega: &E::Fr,
     log_n: u32,
 ) -> gpu::GPUResult<()> {
-    // EvaluationDomain module is supposed to work only with E::Fr elements, and not CurveProjective
-    // points. The Bellman authors have implemented an unnecessarry abstraction called Group<E::Fr>
-    // which is implemented for both PrimeField and CurveProjective elements. As nowhere in the code
-    // is the CurveProjective version used, T and E::Fr are guaranteed to be equal and thus have same
-    // size.
-    // For compatibility/performance reasons we decided to transmute the array to the desired type
-    // as it seems safe and needs less modifications in the current structure of Bellman library.
-    let a = unsafe { &mut *(a as *mut [T] as *mut [E::Fr]) };
     kern.radix_fft(a, omega, log_n)?;
     Ok(())
 }
 
 #[allow(clippy::many_single_char_names)]
-pub fn serial_fft<E: Engine, T: Group<E::Fr>>(a: &mut [T], omega: &E::Fr, log_n: u32) {
+pub fn serial_fft<E: Engine>(a: &mut [E::Fr], omega: &E::Fr, log_n: u32) {
     fn bitreverse(mut n: u32, l: u32) -> u32 {
         let mut r = 0;
         for _ in 0..l {
@@ -354,12 +272,12 @@ pub fn serial_fft<E: Engine, T: Group<E::Fr>>(a: &mut [T], omega: &E::Fr, log_n:
             let mut w = E::Fr::one();
             for j in 0..m {
                 let mut t = a[(k + j + m) as usize];
-                t.group_mul_assign(&w);
+                t *= w;
                 let mut tmp = a[(k + j) as usize];
-                tmp.group_sub_assign(&t);
+                tmp -= t;
                 a[(k + j + m) as usize] = tmp;
-                a[(k + j) as usize].group_add_assign(&t);
-                w.mul_assign(&w_m);
+                a[(k + j) as usize] += t;
+                w *= w_m;
             }
 
             k += 2 * m;
@@ -369,8 +287,8 @@ pub fn serial_fft<E: Engine, T: Group<E::Fr>>(a: &mut [T], omega: &E::Fr, log_n:
     }
 }
 
-fn parallel_fft<E: Engine, T: Group<E::Fr>>(
-    a: &mut [T],
+fn parallel_fft<E: Engine>(
+    a: &mut [E::Fr],
     worker: &Worker,
     omega: &E::Fr,
     log_n: u32,
@@ -380,7 +298,7 @@ fn parallel_fft<E: Engine, T: Group<E::Fr>>(
 
     let num_cpus = 1 << log_cpus;
     let log_new_n = log_n - log_cpus;
-    let mut tmp = vec![vec![T::group_zero(); 1 << log_new_n]; num_cpus];
+    let mut tmp = vec![vec![E::Fr::zero(); 1 << log_new_n]; num_cpus];
     let new_omega = omega.pow_vartime(&[num_cpus as u64]);
 
     worker.scope(0, |scope, _| {
@@ -397,15 +315,15 @@ fn parallel_fft<E: Engine, T: Group<E::Fr>>(
                     for s in 0..num_cpus {
                         let idx = (i + (s << log_new_n)) % (1 << log_n);
                         let mut t = a[idx];
-                        t.group_mul_assign(&elt);
-                        tmp.group_add_assign(&t);
-                        elt.mul_assign(&omega_step);
+                        t *= elt;
+                        *tmp += t;
+                        elt *= omega_step;
                     }
-                    elt.mul_assign(&omega_j);
+                    elt *= omega_j;
                 }
 
                 // Perform sub-FFT
-                serial_fft::<E, T>(tmp, &new_omega, log_new_n);
+                serial_fft::<E>(tmp, &new_omega, log_new_n);
             });
         }
     });
@@ -439,28 +357,22 @@ fn polynomial_arith() {
 
         for coeffs_a in 0..70 {
             for coeffs_b in 0..70 {
-                let mut a: Vec<_> = (0..coeffs_a)
-                    .map(|_| Scalar::<E>(E::Fr::random(&mut *rng)))
-                    .collect();
-                let mut b: Vec<_> = (0..coeffs_b)
-                    .map(|_| Scalar::<E>(E::Fr::random(&mut *rng)))
-                    .collect();
+                let mut a: Vec<_> = (0..coeffs_a).map(|_| E::Fr::random(&mut *rng)).collect();
+                let mut b: Vec<_> = (0..coeffs_b).map(|_| E::Fr::random(&mut *rng)).collect();
 
                 // naive evaluation
-                let mut naive = vec![Scalar(E::Fr::zero()); coeffs_a + coeffs_b];
+                let mut naive = vec![E::Fr::zero(); coeffs_a + coeffs_b];
                 for (i1, a) in a.iter().enumerate() {
                     for (i2, b) in b.iter().enumerate() {
-                        let mut prod = *a;
-                        prod.group_mul_assign(&b.0);
-                        naive[i1 + i2].group_add_assign(&prod);
+                        naive[i1 + i2] += *a * b;
                     }
                 }
 
-                a.resize(coeffs_a + coeffs_b, Scalar(E::Fr::zero()));
-                b.resize(coeffs_a + coeffs_b, Scalar(E::Fr::zero()));
+                a.resize(coeffs_a + coeffs_b, E::Fr::zero());
+                b.resize(coeffs_a + coeffs_b, E::Fr::zero());
 
-                let mut a = EvaluationDomain::from_coeffs(a).unwrap();
-                let mut b = EvaluationDomain::from_coeffs(b).unwrap();
+                let mut a = EvaluationDomain::<E>::from_coeffs(a).unwrap();
+                let mut b = EvaluationDomain::<E>::from_coeffs(b).unwrap();
 
                 a.fft(&worker, &mut None).unwrap();
                 b.fft(&worker, &mut None).unwrap();
@@ -493,10 +405,10 @@ fn fft_composition() {
 
             let mut v = vec![];
             for _ in 0..coeffs {
-                v.push(Scalar::<E>(E::Fr::random(&mut *rng)));
+                v.push(E::Fr::random(&mut *rng));
             }
 
-            let mut domain = EvaluationDomain::<E, _>::from_coeffs(v.clone()).unwrap();
+            let mut domain = EvaluationDomain::<E>::from_coeffs(v.clone()).unwrap();
             domain.ifft(&worker, &mut None).unwrap();
             domain.fft(&worker, &mut None).unwrap();
             assert!(v == domain.coeffs);
@@ -530,15 +442,13 @@ fn parallel_fft_consistency() {
             for log_d in 0..10 {
                 let d = 1 << log_d;
 
-                let v1 = (0..d)
-                    .map(|_| Scalar::<E>(E::Fr::random(&mut *rng)))
-                    .collect::<Vec<_>>();
-                let mut v1 = EvaluationDomain::<E, _>::from_coeffs(v1).unwrap();
-                let mut v2 = EvaluationDomain::<E, _>::from_coeffs(v1.coeffs.clone()).unwrap();
+                let v1 = (0..d).map(|_| E::Fr::random(&mut *rng)).collect::<Vec<_>>();
+                let mut v1 = EvaluationDomain::<E>::from_coeffs(v1).unwrap();
+                let mut v2 = EvaluationDomain::<E>::from_coeffs(v1.coeffs.clone()).unwrap();
 
                 for log_cpus in log_d..min(log_d + 1, 3) {
-                    parallel_fft::<E, _>(&mut v1.coeffs, &worker, &v1.omega, log_d, log_cpus);
-                    serial_fft::<E, _>(&mut v2.coeffs, &v2.omega, log_d);
+                    parallel_fft::<E>(&mut v1.coeffs, &worker, &v1.omega, log_d, log_cpus);
+                    serial_fft::<E>(&mut v2.coeffs, &v2.omega, log_d);
 
                     assert!(v1.coeffs == v2.coeffs);
                 }
@@ -570,7 +480,7 @@ where
 #[cfg(any(feature = "cuda", feature = "opencl"))]
 #[cfg(test)]
 mod tests {
-    use crate::domain::{gpu_fft, parallel_fft, serial_fft, EvaluationDomain, Scalar};
+    use crate::domain::{gpu_fft, parallel_fft, serial_fft, EvaluationDomain};
     use crate::gpu;
     use crate::multicore::Worker;
     use blstrs::{Bls12, Scalar as Fr};
@@ -591,11 +501,9 @@ mod tests {
         for log_d in 1..=20 {
             let d = 1 << log_d;
 
-            let elems = (0..d)
-                .map(|_| Scalar::<Bls12>(Fr::random(&mut rng)))
-                .collect::<Vec<_>>();
-            let mut v1 = EvaluationDomain::<Bls12, _>::from_coeffs(elems.clone()).unwrap();
-            let mut v2 = EvaluationDomain::<Bls12, _>::from_coeffs(elems.clone()).unwrap();
+            let elems = (0..d).map(|_| Fr::random(&mut rng)).collect::<Vec<_>>();
+            let mut v1 = EvaluationDomain::<Bls12>::from_coeffs(elems.clone()).unwrap();
+            let mut v2 = EvaluationDomain::<Bls12>::from_coeffs(elems.clone()).unwrap();
 
             println!("Testing FFT for {} elements...", d);
 
@@ -606,9 +514,9 @@ mod tests {
 
             now = Instant::now();
             if log_d <= log_cpus {
-                serial_fft::<Bls12, _>(&mut v2.coeffs, &v2.omega, log_d);
+                serial_fft::<Bls12>(&mut v2.coeffs, &v2.omega, log_d);
             } else {
-                parallel_fft::<Bls12, _>(&mut v2.coeffs, &worker, &v2.omega, log_d, log_cpus);
+                parallel_fft::<Bls12>(&mut v2.coeffs, &worker, &v2.omega, log_d, log_cpus);
             }
             let cpu_dur = now.elapsed().as_secs() * 1000 + now.elapsed().subsec_millis() as u64;
             println!("CPU ({} cores) took {}ms.", 1 << log_cpus, cpu_dur);


### PR DESCRIPTION
This required us to use `unsafe` casting, even though we don't actually make use of the abstraction 
anywhere. With it gone, so is the `unsafe` casting.

Depends on #205 

