### PR TITLE
refactor: move GPU lock into the locked kernel logic

### DIFF
--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -123,7 +123,6 @@ where
     E: Engine + GpuEngine,
 {
     kernels: Vec<SingleFftKernel<E>>,
-    _lock: locks::GPULock, // RFC 1857: struct fields are dropped in the same order as they are declared.
 }
 
 impl<E> FFTKernel<E>
@@ -131,8 +130,6 @@ where
     E: Engine + GpuEngine,
 {
     pub fn create(priority: bool) -> GPUResult<FFTKernel<E>> {
-        let lock = locks::GPULock::lock();
-
         let kernels: Vec<_> = Device::all()
             .iter()
             .filter_map(|device| {
@@ -156,10 +153,7 @@ where
             info!("FFT: Device {}: {}", i, k.program.device_name(),);
         }
 
-        Ok(FFTKernel {
-            kernels,
-            _lock: lock,
-        })
+        Ok(FFTKernel { kernels })
     }
 
     /// Performs FFT on `a`

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -220,7 +220,6 @@ where
     E: Engine + GpuEngine,
 {
     kernels: Vec<SingleMultiexpKernel<E>>,
-    _lock: locks::GPULock, // RFC 1857: struct fields are dropped in the same order as they are declared.
 }
 
 impl<E> MultiexpKernel<E>
@@ -228,8 +227,6 @@ where
     E: Engine + GpuEngine,
 {
     pub fn create(priority: bool) -> GPUResult<MultiexpKernel<E>> {
-        let lock = locks::GPULock::lock();
-
         let kernels: Vec<_> = Device::all()
             .iter()
             .filter_map(|device| {
@@ -261,10 +258,7 @@ where
                 k.n
             );
         }
-        Ok(MultiexpKernel::<E> {
-            kernels,
-            _lock: lock,
-        })
+        Ok(MultiexpKernel::<E> { kernels })
     }
 
     pub fn multiexp<G>(


### PR DESCRIPTION
Instead on holding the GPU lock within each kernel implementation,
do the locking within the locked kernel abstraction.