### PR TITLE
Add Comparable trait for comparing constraint systems.

### DIFF
--- a/src/lc.rs
+++ b/src/lc.rs
@@ -32,13 +32,13 @@ pub enum Index {
 
 /// This represents a linear combination of some variables, with coefficients
 /// in the scalar field of a pairing-friendly elliptic curve group.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LinearCombination<Scalar: PrimeField> {
     inputs: Indexer<Scalar>,
     aux: Indexer<Scalar>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 struct Indexer<T> {
     /// Stores a list of `T` indexed by the number in the first slot of the tuple.
     values: Vec<(usize, T)>,

--- a/src/util_cs/metric_cs.rs
+++ b/src/util_cs/metric_cs.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 
+use super::Comparable;
 use ff::PrimeField;
 
 use crate::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
@@ -45,15 +46,28 @@ impl Ord for OrderedVariable {
 pub struct MetricCS<Scalar: PrimeField> {
     named_objects: HashMap<String, NamedObject>,
     current_namespace: Vec<String>,
-    #[allow(clippy::type_complexity)]
-    constraints: Vec<(
-        LinearCombination<Scalar>,
-        LinearCombination<Scalar>,
-        LinearCombination<Scalar>,
-        String,
-    )>,
+    constraints: Vec<crate::util_cs::Constraint<Scalar>>,
     inputs: Vec<String>,
     aux: Vec<String>,
+}
+impl<Scalar: PrimeField> Comparable<Scalar> for MetricCS<Scalar> {
+    fn num_inputs(&self) -> usize {
+        self.num_inputs()
+    }
+    fn num_constraints(&self) -> usize {
+        self.num_constraints()
+    }
+
+    fn aux(&self) -> Vec<String> {
+        self.aux.clone()
+    }
+
+    fn inputs(&self) -> Vec<String> {
+        self.inputs.clone()
+    }
+    fn constraints(&self) -> &[crate::util_cs::Constraint<Scalar>] {
+        &self.constraints
+    }
 }
 
 fn proc_lc<Scalar: PrimeField>(

--- a/src/util_cs/mod.rs
+++ b/src/util_cs/mod.rs
@@ -1,3 +1,86 @@
+use crate::LinearCombination;
+use ff::PrimeField;
+
 pub mod bench_cs;
 pub mod metric_cs;
 pub mod test_cs;
+
+pub type Constraint<Scalar> = (
+    LinearCombination<Scalar>,
+    LinearCombination<Scalar>,
+    LinearCombination<Scalar>,
+    String,
+);
+
+pub trait Comparable<Scalar: PrimeField> {
+    /// The `Comparable` trait allows comparison of two constraint systems which
+    /// implement the trait. The only non-trivial method, `delta`, has a default
+    /// implementation which supplies the desired behavior.
+    ///
+    /// Use `delta` to compare constraint systems. If they are not identical, the
+    /// returned `Delta` enum contains fine-grained information about how they
+    /// differ. This can be especially useful when debugging the situation in which
+    /// a constraint system is satisfied, but the corresponding Groth16 proof does
+    /// not verify.
+    ///
+    /// Example usage:
+    ///
+    /// ```norun
+    /// let delta = cs.delta(&cs_blank);
+    /// assert!(delta == Delta::Equal);
+    /// ```
+    fn num_inputs(&self) -> usize;
+    fn num_constraints(&self) -> usize;
+    fn inputs(&self) -> Vec<String>;
+    fn aux(&self) -> Vec<String>;
+    fn constraints(&self) -> &[Constraint<Scalar>];
+
+    fn delta<C: Comparable<Scalar>>(&self, other: &C) -> Delta<Scalar>
+    where
+        Scalar: PrimeField,
+    {
+        let input_count_matches = self.num_inputs() == other.num_inputs();
+        let constraint_count_matches = self.num_constraints() == other.num_constraints();
+
+        let inputs_match = self.inputs() == other.inputs();
+        let constraints_match = self.constraints() == other.constraints();
+
+        let equal =
+            input_count_matches && constraint_count_matches && inputs_match && constraints_match;
+
+        if !input_count_matches {
+            Delta::InputCountMismatch(self.num_inputs(), other.num_inputs())
+        } else if !constraint_count_matches {
+            Delta::ConstraintCountMismatch(self.num_constraints(), other.num_constraints())
+        } else if !constraints_match {
+            let c = self.constraints();
+            let o = other.constraints();
+
+            let mismatch = c
+                .iter()
+                .zip(o)
+                .filter(|(a, b)| a != b)
+                .enumerate()
+                .map(|(i, (a, b))| (i, a, b))
+                .next();
+
+            let m = mismatch.unwrap();
+
+            Delta::ConstraintMismatch(m.0, m.1.clone(), m.2.clone())
+        } else if equal {
+            Delta::Equal
+        } else {
+            Delta::Different
+        }
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum Delta<Scalar: PrimeField> {
+    Equal,
+    Different,
+    InputCountMismatch(usize, usize),
+    ConstraintCountMismatch(usize, usize),
+    ConstraintMismatch(usize, Constraint<Scalar>, Constraint<Scalar>),
+}

--- a/src/util_cs/mod.rs
+++ b/src/util_cs/mod.rs
@@ -59,8 +59,8 @@ pub trait Comparable<Scalar: PrimeField> {
             let mismatch = c
                 .iter()
                 .zip(o)
-                .filter(|(a, b)| a != b)
                 .enumerate()
+                .filter(|(_, (a, b))| a != b)
                 .map(|(i, (a, b))| (i, a, b))
                 .next();
 

--- a/src/util_cs/test_cs.rs
+++ b/src/util_cs/test_cs.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
+use super::Comparable;
 use crate::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 use blake2s_simd::State as Blake2s;
 use byteorder::{BigEndian, ByteOrder};
@@ -314,6 +315,32 @@ impl<Scalar: PrimeField> TestConstraintSystem<Scalar> {
         }
 
         self.named_objects.insert(path, to);
+    }
+}
+
+impl<Scalar: PrimeField> Comparable<Scalar> for TestConstraintSystem<Scalar> {
+    fn num_inputs(&self) -> usize {
+        self.num_inputs()
+    }
+    fn num_constraints(&self) -> usize {
+        self.num_constraints()
+    }
+
+    fn aux(&self) -> Vec<String> {
+        self.aux
+            .iter()
+            .map(|(_scalar, string)| string.to_string())
+            .collect()
+    }
+
+    fn inputs(&self) -> Vec<String> {
+        self.inputs
+            .iter()
+            .map(|(_scalar, string)| string.to_string())
+            .collect()
+    }
+    fn constraints(&self) -> &[crate::util_cs::Constraint<Scalar>] {
+        &self.constraints
     }
 }
 


### PR DESCRIPTION
This PR adds a trait, `Comparable` and implements it for `MetricCS` and `TestConstraintSystem`. It allows for a more comprehensive comparison of synthesized constraint systems. This is especially helpful for cases where a constraint system is satisfied and verifies with public inputs — but the corresponding Groth16 proof fails to verify on those public inputs. This can be frustrating to debug…

After synthesizing a blank and non-blank constraint system, compare using the `delta` method, which returns a `Delta` enum which is either `Delta::Equal` or contains more specific information if they differ. When constraint systems differ only by the content of their constraints, it is extremely helpful to know which constraints differ.

`Delta::ConstraintMismatch` includes the first mismatched constraint and its index, providing a foothold into debugging.

Usage example:

```
            let mut cs_blank = MetricCS::<Fr>::new();
            let blank_frame = Frame::blank();

            blank_frame
                .synthesize(&mut cs_blank)
                .expect("failed to synthesize");

            let mut cs = TestConstraintSystem::new();
            let frame = Frame {
                input: Some(input.clone()),
                output: Some(output),
                initial: Some(initial.clone()),
                i: Some(0),
                witness: Some(witness.clone()),
            };

            frame
                .synthesize(&mut cs)
                .expect("failed to synthesize");

            let delta = cs.delta(&cs_blank);
            assert!(delta == Delta::Equal);
```
