### PR TITLE
Solution to error "mined block in the past"

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -514,11 +514,11 @@ fn parallel_fft_consistency() {
     test_consistency::<Bls12, _>(rng);
 }
 
-pub fn create_fft_kernel<E>(_log_d: usize, priority: bool) -> Option<gpu::FFTKernel<E>>
+pub fn create_fft_kernel<E>(_log_d: usize, priority: bool, isWinPost: bool) -> Option<gpu::FFTKernel<E>>
 where
     E: Engine + gpu::GpuEngine,
 {
-    match gpu::FFTKernel::create(priority) {
+    match gpu::FFTKernel::create(priority, isWinPost) {
         Ok(k) => {
             info!("GPU FFT kernel instantiated!");
             Some(k)

--- a/src/gpu/fft.rs
+++ b/src/gpu/fft.rs
@@ -130,10 +130,10 @@ impl<E> FFTKernel<E>
 where
     E: Engine + GpuEngine,
 {
-    pub fn create(priority: bool) -> GPUResult<FFTKernel<E>> {
-        let lock = locks::GPULock::lock();
+    pub fn create(priority: bool, isWinPost: bool) -> GPUResult<FFTKernel<E>> {
+        let lock = locks::GPULock::lock(isWinPost);
 
-        let kernels: Vec<_> = Device::all()
+        let mut kernels_local: Vec<_> = Device::all()
             .iter()
             .filter_map(|device| {
                 let kernel = SingleFftKernel::<E>::create(device, priority);
@@ -148,18 +148,38 @@ where
             })
             .collect();
 
-        if kernels.is_empty() {
+        if kernels_local.is_empty() {
             return Err(GPUError::Simple("No working GPUs found!"));
         }
-        info!("FFT: {} working device(s) selected. ", kernels.len());
-        for (i, k) in kernels.iter().enumerate() {
+        info!("FFT: {} working device(s) selected. ", kernels_local.len());
+        for (i, k) in kernels_local.iter().enumerate() {
             info!("FFT: Device {}: {}", i, k.program.device_name(),);
         }
 
-        Ok(FFTKernel {
-            kernels,
-            _lock: lock,
-        })
+        if kernels_local.len() > 1 {
+            if isWinPost {
+                kernels_local.remove(1);
+                let kernels = kernels_local;
+                info!("FFT: Choose device 0: {} for winning post.", kernels_local[0].program.device_name());
+                Ok(FFTKernel::<E> {
+                    kernels,
+                    _lock: lock,
+                })
+            } else {
+                kernels_local.remove(0);
+                let kernels = kernels_local;
+                Ok(FFTKernel::<E> {
+                    kernels,
+                    _lock: lock,
+                })
+            }
+        } else {
+            let kernels = kernels_local;
+            Ok(FFTKernel::<E> {
+                kernels,
+                _lock: lock,
+            })
+        }
     }
 
     /// Performs FFT on `a`

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -5,8 +5,12 @@ use std::path::PathBuf;
 
 const GPU_LOCK_NAME: &str = "bellman.gpu.lock";
 const PRIORITY_LOCK_NAME: &str = "bellman.priority.lock";
-fn tmp_path(filename: &str) -> PathBuf {
+fn tmp_path(filename: &str, isWinPost: bool) -> PathBuf {
     let mut p = std::env::temp_dir();
+    if isWinPost {
+        let key = std::env::var("WINPOST_TMPDIR").unwrap();
+        p = PathBuf::from(key);
+    }
     p.push(filename);
     p
 }
@@ -16,8 +20,8 @@ fn tmp_path(filename: &str) -> PathBuf {
 #[derive(Debug)]
 pub struct GPULock(File);
 impl GPULock {
-    pub fn lock() -> GPULock {
-        let gpu_lock_file = tmp_path(GPU_LOCK_NAME);
+    pub fn lock(isWinPost: bool) -> GPULock {
+        let gpu_lock_file = tmp_path(GPU_LOCK_NAME, isWinPost);
         debug!("Acquiring GPU lock at {:?} ...", &gpu_lock_file);
         let f = File::create(&gpu_lock_file)
             .unwrap_or_else(|_| panic!("Cannot create GPU lock file at {:?}", &gpu_lock_file));
@@ -40,8 +44,8 @@ impl Drop for GPULock {
 #[derive(Debug)]
 pub struct PriorityLock(File);
 impl PriorityLock {
-    pub fn lock() -> PriorityLock {
-        let priority_lock_file = tmp_path(PRIORITY_LOCK_NAME);
+    pub fn lock(isWinPost: bool) -> PriorityLock {
+        let priority_lock_file = tmp_path(PRIORITY_LOCK_NAME, isWinPost);
         debug!("Acquiring priority lock at {:?} ...", &priority_lock_file);
         let f = File::create(&priority_lock_file).unwrap_or_else(|_| {
             panic!(
@@ -54,9 +58,9 @@ impl PriorityLock {
         PriorityLock(f)
     }
 
-    pub fn wait(priority: bool) {
+    pub fn wait(priority: bool, isWinPost: bool) {
         if !priority {
-            if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME))
+            if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME, isWinPost))
                 .unwrap()
                 .lock_exclusive()
             {
@@ -69,7 +73,7 @@ impl PriorityLock {
         if priority {
             return false;
         }
-        if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME))
+        if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME, false))
             .unwrap()
             .try_lock_shared()
         {
@@ -106,6 +110,7 @@ macro_rules! locked_kernel {
         {
             log_d: usize,
             priority: bool,
+            isWinPost: bool,
             kernel: Option<$kern<E>>,
         }
 
@@ -113,19 +118,20 @@ macro_rules! locked_kernel {
         where
             E: pairing::Engine + crate::gpu::GpuEngine,
         {
-            pub fn new(log_d: usize, priority: bool) -> $class<E> {
+            pub fn new(log_d: usize, priority: bool, isWinPost: bool) -> $class<E> {
                 $class::<E> {
                     log_d,
                     priority,
+                    isWinPost,
                     kernel: None,
                 }
             }
 
             fn init(&mut self) {
                 if self.kernel.is_none() {
-                    PriorityLock::wait(self.priority);
+                    PriorityLock::wait(self.priority, self.isWinPost);
                     info!("GPU is available for {}!", $name);
-                    self.kernel = $func::<E>(self.log_d, self.priority);
+                    self.kernel = $func::<E>(self.log_d, self.priority, self.isWinPost);
                 }
             }
 

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -227,10 +227,10 @@ impl<E> MultiexpKernel<E>
 where
     E: Engine + GpuEngine,
 {
-    pub fn create(priority: bool) -> GPUResult<MultiexpKernel<E>> {
-        let lock = locks::GPULock::lock();
+    pub fn create(priority: bool, isWinPost: bool) -> GPUResult<MultiexpKernel<E>> {
+        let lock = locks::GPULock::lock(isWinPost);
 
-        let kernels: Vec<_> = Device::all()
+        let mut kernels_local: Vec<_> = Device::all()
             .iter()
             .filter_map(|device| {
                 let kernel = SingleMultiexpKernel::<E>::create(device, priority);
@@ -245,15 +245,15 @@ where
             })
             .collect();
 
-        if kernels.is_empty() {
+        if kernels_local.is_empty() {
             return Err(GPUError::Simple("No working GPUs found!"));
         }
         info!(
             "Multiexp: {} working device(s) selected. (CPU utilization: {})",
-            kernels.len(),
+            kernels_local.len(),
             get_cpu_utilization()
         );
-        for (i, k) in kernels.iter().enumerate() {
+        for (i, k) in kernels_local.iter().enumerate() {
             info!(
                 "Multiexp: Device {}: {} (Chunk-size: {})",
                 i,
@@ -261,10 +261,30 @@ where
                 k.n
             );
         }
-        Ok(MultiexpKernel::<E> {
-            kernels,
-            _lock: lock,
-        })
+        if kernels_local.len() > 1 {
+            if isWinPost {
+                kernels_local.remove(1);
+                let kernels = kernels_local;
+                info!("Multiexp: Choose device 0: {} for winning post.", kernels_local[0].program.device_name());
+                Ok(MultiexpKernel::<E> {
+                    kernels,
+                    _lock: lock,
+                })
+            } else {
+                kernels_local.remove(0);
+                let kernels = kernels_local;
+                Ok(MultiexpKernel::<E> {
+                    kernels,
+                    _lock: lock,
+                })
+            }
+        } else {
+            let kernels = kernels_local;
+            Ok(MultiexpKernel::<E> {
+                kernels,
+                _lock: lock,
+            })
+        }
     }
 
     pub fn multiexp<G>(

--- a/src/groth16/ext.rs
+++ b/src/groth16/ext.rs
@@ -15,7 +15,7 @@ where
     C: Circuit<E::Fr> + Send,
 {
     let proofs =
-        create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], false)?;
+        create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], false, false)?;
     Ok(proofs.into_iter().next().unwrap())
 }
 
@@ -30,7 +30,7 @@ where
     R: RngCore,
 {
     let proofs =
-        create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, false)?;
+        create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, false, false)?;
     Ok(proofs.into_iter().next().unwrap())
 }
 
@@ -44,20 +44,21 @@ where
     E: gpu::GpuEngine + MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
 {
-    create_proof_batch_priority::<E, C, P>(circuits, params, r, s, false)
+    create_proof_batch_priority::<E, C, P>(circuits, params, r, s, false, false)
 }
 
 pub fn create_random_proof_batch<E, C, R, P: ParameterSource<E>>(
     circuits: Vec<C>,
     params: P,
     rng: &mut R,
+    isWinPost: bool,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
     E: gpu::GpuEngine + MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
 {
-    create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, false)
+    create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, false, isWinPost)
 }
 
 pub fn create_proof_in_priority<E, C, P: ParameterSource<E>>(
@@ -71,7 +72,7 @@ where
     C: Circuit<E::Fr> + Send,
 {
     let proofs =
-        create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], true)?;
+        create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], true, false)?;
     Ok(proofs.into_iter().next().unwrap())
 }
 
@@ -86,7 +87,7 @@ where
     R: RngCore,
 {
     let proofs =
-        create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, true)?;
+        create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, true, false)?;
     Ok(proofs.into_iter().next().unwrap())
 }
 
@@ -100,18 +101,19 @@ where
     E: gpu::GpuEngine + MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
 {
-    create_proof_batch_priority::<E, C, P>(circuits, params, r, s, true)
+    create_proof_batch_priority::<E, C, P>(circuits, params, r, s, true, false)
 }
 
 pub fn create_random_proof_batch_in_priority<E, C, R, P: ParameterSource<E>>(
     circuits: Vec<C>,
     params: P,
     rng: &mut R,
+    isWinPost: bool,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
     E: gpu::GpuEngine + MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
 {
-    create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, true)
+    create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, true, isWinPost)
 }

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -446,11 +446,11 @@ fn test_with_bls12() {
     assert_eq!(naive, fast);
 }
 
-pub fn create_multiexp_kernel<E>(_log_d: usize, priority: bool) -> Option<gpu::MultiexpKernel<E>>
+pub fn create_multiexp_kernel<E>(_log_d: usize, priority: bool, isWinPost: bool) -> Option<gpu::MultiexpKernel<E>>
 where
     E: Engine + gpu::GpuEngine,
 {
-    match gpu::MultiexpKernel::<E>::create(priority) {
+    match gpu::MultiexpKernel::<E>::create(priority, isWinPost) {
         Ok(k) => {
             info!("GPU Multiexp kernel instantiated!");
             Some(k)


### PR DESCRIPTION
This PR gives a solution to error "mined block in the past" due to windowpost and winpost happening at the same time. 

- Add a flag to identify whether it is winning post or not when doing fft and multiexp calculation.
- Add an env. variable: WINPOST_TMPDIR as a path to hold the gpu_lock_file and priority_lock_file when doing winning post.

 Make sure to set the env. variable: WINPOST_TMPDIR, and not to set the env. variable: CUDA_VISIBLE_DEVICES, when running lotus-miner. 
 
It is suggested to put two GPUs on the miner box. It would select the first GPU for winning post and the second GPU for window post.

related discussion: https://github.com/filecoin-project/lotus/discussions/7797