### PR TITLE
feat: add CUDA recognized GPU naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Depending on the size of the proof being passed to the gpu for work, certain car
 | Tesla T4               | 2560  |                |
 | Quadro M5000           | 2048  |                |
 | GeForce RTX 3090       |10496  |                |
+| GeForce RTX 3090 Ti    |10240  |                |
 | GeForce RTX 3080       | 8704  |                |
 | GeForce RTX 3070       | 5888  |                |
 | GeForce RTX 2080 Ti    | 4352  |                |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Depending on the size of the proof being passed to the gpu for work, certain car
 | Tesla T4               | 2560  |                |
 | Quadro M5000           | 2048  |                |
 | GeForce RTX 3090       |10496  |                |
-| GeForce RTX 3090 Ti    |10240  |                |
+| GeForce RTX 3080 Ti    |10240  |                |
 | GeForce RTX 3080       | 8704  |                |
 | GeForce RTX 3070       | 5888  |                |
 | GeForce RTX 2080 Ti    | 4352  |                |

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -24,6 +24,7 @@ lazy_static::lazy_static! {
 
             ("GeForce RTX 3090".to_string(), 10496),
             ("GeForce RTX 3080".to_string(), 8704),
+            ("GeForce RTX 3080 Ti".to_string(), 8704),
             ("GeForce RTX 3070".to_string(), 5888),
 
             ("GeForce RTX 2080 Ti".to_string(), 4352),
@@ -38,6 +39,25 @@ lazy_static::lazy_static! {
             ("GeForce GTX 1060".to_string(), 1280),
             ("GeForce GTX 1650 SUPER".to_string(), 1280),
             ("GeForce GTX 1650".to_string(), 896),
+
+            // CUDA appears to have a different device name
+            ("NVIDIA GeForce RTX 3090".to_string(), 10496),
+            ("NVIDIA GeForce RTX 3080".to_string(), 8704),
+            ("NVIDIA GeForce RTX 3080 Ti".to_string(), 8704),
+            ("NVIDIA GeForce RTX 3070".to_string(), 5888),
+
+            ("NVIDIA GeForce RTX 2080 Ti".to_string(), 4352),
+            ("NVIDIA GeForce RTX 2080 SUPER".to_string(), 3072),
+            ("NVIDIA GeForce RTX 2080".to_string(), 2944),
+            ("NVIDIA GeForce RTX 2070 SUPER".to_string(), 2560),
+
+            ("NVIDIA GeForce GTX 1080 Ti".to_string(), 3584),
+            ("NVIDIA GeForce GTX 1080".to_string(), 2560),
+            ("NVIDIA GeForce GTX 2060".to_string(), 1920),
+            ("NVIDIA GeForce GTX 1660 Ti".to_string(), 1536),
+            ("NVIDIA GeForce GTX 1060".to_string(), 1280),
+            ("NVIDIA GeForce GTX 1650 SUPER".to_string(), 1280),
+            ("NVIDIA GeForce GTX 1650".to_string(), 896),
         ].into_iter().collect();
 
         if let Ok(var) = env::var("BELLMAN_CUSTOM_GPU") {

--- a/src/gpu/utils.rs
+++ b/src/gpu/utils.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
 
             ("GeForce RTX 3090".to_string(), 10496),
             ("GeForce RTX 3080".to_string(), 8704),
-            ("GeForce RTX 3080 Ti".to_string(), 8704),
+            ("GeForce RTX 3080 Ti".to_string(), 10240),
             ("GeForce RTX 3070".to_string(), 5888),
 
             ("GeForce RTX 2080 Ti".to_string(), 4352),
@@ -43,7 +43,7 @@ lazy_static::lazy_static! {
             // CUDA appears to have a different device name
             ("NVIDIA GeForce RTX 3090".to_string(), 10496),
             ("NVIDIA GeForce RTX 3080".to_string(), 8704),
-            ("NVIDIA GeForce RTX 3080 Ti".to_string(), 8704),
+            ("NVIDIA GeForce RTX 3080 Ti".to_string(), 10240),
             ("NVIDIA GeForce RTX 3070".to_string(), 5888),
 
             ("NVIDIA GeForce RTX 2080 Ti".to_string(), 4352),


### PR DESCRIPTION
Not 100% sure this solves all naming issues, but its resolves 2080 Ti and 3080 Ti issues found locally.