### PR TITLE
fix: use Cuda cores determination from rust-gpu-tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ pairing = "0.21"
 yastl = "0.1.2"
 
 # cuda/opencl feature
-rust-gpu-tools = { version = "0.5.0", optional = true, default-features = false }
+rust-gpu-tools = { version = "0.6.0", optional = true, default-features = false }
 ec-gpu = { version = "0.1.0", optional = true }
 ec-gpu-gen = { version = "0.1.0", optional = true }
 fs2 = { version = "0.4.3", optional = true }
@@ -53,6 +53,7 @@ rand_chacha = "0.3"
 csv = "1.1.5"
 tempfile = "3.1.0"
 subtle = "2.2.1"
+temp-env = "0.2.0"
 
 [build-dependencies]
 blstrs = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ The gpu extension contains some env vars that may be set externally to this libr
     env::set_var("BELLMAN_VERIFIER", "gpu");
     ```
 
-- `BELLMAN_CUSTOM_GPU`
+- `RUST_GPU_TOOLS_CUSTOM_GPU`
 
     Will allow for adding a GPU not in the tested list. This requires researching the name of the GPU device and the number of cores in the format `["name:cores"]`.
 
     ```rust
     // Example
-    env::set_var("BELLMAN_CUSTOM_GPU", "GeForce RTX 2080 Ti:4352, GeForce GTX 1060:1280");
+    env::set_var("RUST_GPU_TOOLS_CUSTOM_GPU", "GeForce RTX 2080 Ti:4352, GeForce GTX 1060:1280");
     ```
 
 - `BELLMAN_CPU_UTILIZATION`

--- a/tests/envvars1.rs
+++ b/tests/envvars1.rs
@@ -1,0 +1,25 @@
+#![cfg(any(feature = "cuda", feature = "opencl"))]
+// This test is in its own file as the `RUST_GPU_TOOLS_CUSTOM_GPU` variable is checked only when
+// `get_core_count` is accessed for the first time. Subsequent calls will return the values it was
+// set to on the first call.
+use std::env;
+
+use bellperson::gpu::get_core_count;
+
+/// Make sure that setting the `BELLMAN_CUSTOM_GPU` env var still works.
+#[test]
+fn belllman_custom_gpu_env_var() {
+    temp_env::with_vars(
+        vec![
+            ("BELLMAN_CUSTOM_GPU", Some("My custom GPU:3241")),
+            ("RUST_GPU_TOOLS_CUSTOM_GPU", None),
+        ],
+        || {
+            let cores = get_core_count("My custom GPU");
+            let rust_gpu_tools_custom_gpu = env::var("RUST_GPU_TOOLS_CUSTOM_GPU")
+                .expect("RUST_GPU_TOOLS_CUSTOM_GPU is set after `get_core_count` was called.");
+            assert_eq!(rust_gpu_tools_custom_gpu, "My custom GPU:3241");
+            assert_eq!(cores, 3241, "Cores of custom GPU were set correctly");
+        },
+    );
+}

--- a/tests/envvars2.rs
+++ b/tests/envvars2.rs
@@ -1,0 +1,25 @@
+#![cfg(any(feature = "cuda", feature = "opencl"))]
+// This test is in its own file as the `RUST_GPU_TOOLS_CUSTOM_GPU` variable is checked only when
+// `get_core_count` is accessed for the first time. Subsequent calls will return the values it was
+// set to on the first call.
+use std::env;
+
+use bellperson::gpu::get_core_count;
+
+/// Make sure that `BELLMAN_CUSTOM_GPU` env var is ignored if `RUST_GPU_TOOLS_CUSTOM_GPU` is
+/// set.
+#[test]
+fn belllman_custom_gpu_env_var_ignored() {
+    temp_env::with_vars(
+        vec![
+            ("RUST_GPU_TOOLS_CUSTOM_GPU", Some("My custom GPU:444")),
+            ("BELLMAN_CUSTOM_GPU", Some("My custom GPU:3242")),
+        ],
+        || {
+            let cores = get_core_count("My custom GPU");
+            env::var("RUST_GPU_TOOLS_CUSTOM_GPU")
+                .expect("RUST_GPU_TOOLS_CUSTOM_GPU is set after `get_core_count` was called.");
+            assert_eq!(cores, 444, "Cores of custom GPU were set correctly to the `RUST_GPU_TOOLS_CUSTOM_GPU` env var.");
+        },
+    );
+}


### PR DESCRIPTION
Determining the number of cores is generally useful, so it was moved
to the rust-gpu-tools library. In order to set a custom GPU please
use the `RUST_GPU_TOOLS_CUSTOM_GPU` variable instead of
`BELLMAN_CUSTOM_GPU`.