### PR TITLE
refactor: remove no longer used log_d parameter

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -514,7 +514,7 @@ fn parallel_fft_consistency() {
     test_consistency::<Bls12, _>(rng);
 }
 
-pub fn create_fft_kernel<E>(_log_d: usize, priority: bool) -> Option<gpu::FFTKernel<E>>
+pub fn create_fft_kernel<E>(priority: bool) -> Option<gpu::FFTKernel<E>>
 where
     E: Engine + gpu::GpuEngine,
 {
@@ -550,7 +550,7 @@ mod tests {
 
         let worker = Worker::new();
         let log_cpus = worker.log_num_cpus();
-        let mut locked_kern = gpu::LockedFFTKernel::<Bls12>::new(0, false);
+        let mut locked_kern = gpu::LockedFFTKernel::<Bls12>::new(false);
 
         for log_d in 1..=20 {
             let d = 1 << log_d;
@@ -595,7 +595,7 @@ mod tests {
 
         let worker = Worker::new();
         let log_cpus = worker.log_num_cpus();
-        let mut locked_kern = gpu::LockedFFTKernel::<Bls12>::new(0, false);
+        let mut locked_kern = gpu::LockedFFTKernel::<Bls12>::new(false);
 
         for log_d in 1..=20 {
             let d = 1 << log_d;

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -104,7 +104,6 @@ macro_rules! locked_kernel {
         where
             E: pairing::Engine + crate::gpu::GpuEngine,
         {
-            log_d: usize,
             priority: bool,
             kernel: Option<$kern<E>>,
             // There should always be only one thing running on the GPU, hence create a
@@ -116,9 +115,8 @@ macro_rules! locked_kernel {
         where
             E: pairing::Engine + crate::gpu::GpuEngine,
         {
-            pub fn new(log_d: usize, priority: bool) -> $class<E> {
+            pub fn new(priority: bool) -> $class<E> {
                 $class::<E> {
-                    log_d,
                     priority,
                     kernel: None,
                     gpu_lock: None,
@@ -130,7 +128,7 @@ macro_rules! locked_kernel {
                     PriorityLock::wait(self.priority);
                     info!("GPU is available for {}!", $name);
                     self.gpu_lock = Some(GPULock::lock());
-                    self.kernel = $func::<E>(self.log_d, self.priority);
+                    self.kernel = $func::<E>(self.priority);
                 }
             }
 

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -70,7 +70,7 @@ macro_rules! locked_kernel {
         where
             E: Engine,
         {
-            pub fn new(_: usize, _: bool) -> $class<E> {
+            pub fn new(_: bool) -> $class<E> {
                 $class::<E>(PhantomData)
             }
 

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -289,11 +289,6 @@ where
         );
     }
 
-    let mut log_d = 0;
-    while (1 << log_d) < n {
-        log_d += 1;
-    }
-
     #[cfg(any(feature = "cuda", feature = "opencl"))]
     let prio_lock = if priority {
         trace!("acquiring priority lock");
@@ -315,14 +310,14 @@ where
             *params_h = Some(params.get_h(n));
         });
 
-        let mut fft_kern = Some(LockedFFTKernel::<E>::new(log_d, priority));
+        let mut fft_kern = Some(LockedFFTKernel::<E>::new(priority));
         for prover in provers_ref {
             a_s.push(execute_fft(worker, prover, &mut fft_kern)?);
         }
         Ok(())
     })?;
 
-    let mut multiexp_kern = Some(LockedMultiexpKernel::<E>::new(log_d, priority));
+    let mut multiexp_kern = Some(LockedMultiexpKernel::<E>::new(priority));
     let params_h = params_h.unwrap()?;
 
     let mut h_s = Vec::with_capacity(num_circuits);

--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -446,7 +446,7 @@ fn test_with_bls12() {
     assert_eq!(naive, fast);
 }
 
-pub fn create_multiexp_kernel<E>(_log_d: usize, priority: bool) -> Option<gpu::MultiexpKernel<E>>
+pub fn create_multiexp_kernel<E>(priority: bool) -> Option<gpu::MultiexpKernel<E>>
 where
     E: Engine + gpu::GpuEngine,
 {
@@ -474,7 +474,7 @@ pub fn gpu_multiexp_consistency() {
 
     const MAX_LOG_D: usize = 16;
     const START_LOG_D: usize = 10;
-    let mut kern = Some(gpu::LockedMultiexpKernel::<Bls12>::new(MAX_LOG_D, false));
+    let mut kern = Some(gpu::LockedMultiexpKernel::<Bls12>::new(false));
     let pool = Worker::new();
 
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
The `log_d` parameter isn't used by the kernels, hence remote it.