### PR TITLE
Re-export DensityTracker.

### DIFF
--- a/src/multiexp.rs
+++ b/src/multiexp.rs
@@ -8,6 +8,7 @@ use group::prime::PrimeCurveAffine;
 use pairing::Engine;
 
 use crate::gpu;
+pub use ec_gpu_gen::multiexp_cpu::DensityTracker;
 
 /// Perform multi-exponentiation. The caller is responsible for ensuring the
 /// query size is the same as the number of exponents.


### PR DESCRIPTION
#261 moved DensityTracker into the `ec_gpu_gen` crate, breaking downstream usage. This PR re-exports to fix that.