### PR TITLE
chore: update ec-gpu-gen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ blstrs = "0.4.0"
 pairing = "0.21"
 yastl = "0.1.2"
 ec-gpu = { version = "0.1.0"}
-ec-gpu-gen = { version = "0.2.0", default-features = false, features = ["fft", "multiexp"] }
+ec-gpu-gen = { version = "0.2.1", default-features = false, features = ["fft", "multiexp"] }
 
 fs2 = { version = "0.4.3", optional = true }
 


### PR DESCRIPTION
`ec-gpu-gen` had a performance regression on OpenCL, update to at
least the version that has that fix.