### PR TITLE
refactor: do G2 calculations after G1 calculations

### DIFF
--- a/src/groth16/proof.rs
+++ b/src/groth16/proof.rs
@@ -242,6 +242,8 @@ mod test_with_bls12_381 {
 
     #[test]
     fn serialization() {
+        env_logger::try_init().ok();
+
         struct MySillyCircuit<Scalar: PrimeField> {
             a: Option<Scalar>,
             b: Option<Scalar>,


### PR DESCRIPTION
Spliting into distinct G1 and G2 phases prepares for future changes
(when separate kernels are used for G1 and G2). This change doesn't
harm the performance. On 32GiB sectors the performance difference
between runs is bigger than with or without this change.

For micro benchmarks the `groth16::proof::test_with_bls12_381::serialization`
test was run. Below are the average prover times. The tests were always
run twice sequentially, the best run was used.

|    Version    | #GPUs |   CUDA    |  OpenCL   |
| :------------ | ----: | --------: | --------: |
| prior         |     1 | 167.665ms | 379.428ms |
| this change   |     1 | 165.677ms | 370.912ms |
| prior         |     4 | 197.071ms | 1155.59ms |
| this change   |     4 | 198.019ms | 1081.05ms |

The command the tests were run with:

    RUST_LOG=info cargo test --release --features opencl groth16::proof::test_with_bls12_381::serialization 2>&1|grep 'prover time'|awk '/ms$/ { print substr($6, 1, length($6) - 2); next } /s$/ { print substr($6, 1, length($6) - 1) * 1000 }'|awk '{ total += $1; count++ } END { print total/count }

For running in a single GPU `CUDA_VISIBLE_DEVICES=0` was set. For
CUDA vs. OpenCL the `--features` flag was either set to `cuda` or
`opencl`.