### PR TITLE
fix: make it work with latest multiexp kernel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ blstrs = "0.5.0"
 pairing = "0.22"
 yastl = "0.1.2"
 ec-gpu = { version = "0.1.0" }
-ec-gpu-gen = { version = "0.3.0", default-features = false, features = ["fft", "multiexp"] }
+ec-gpu-gen = { version = "0.3.0", default-features = false }
 
 fs2 = { version = "0.4.3", optional = true }
 
@@ -55,8 +55,8 @@ temp-env = "0.2.0"
 
 [features]
 default = ["groth16", "memmap" ]
-cuda = ["ec-gpu-gen/cuda", "fs2", "blstrs/gpu"]
-opencl = ["ec-gpu-gen/opencl", "fs2", "blstrs/gpu"]
+cuda = ["ec-gpu-gen/bls12-381", "ec-gpu-gen/cuda", "fs2", "blstrs/gpu"]
+opencl = ["ec-gpu-gen/bls12-381", "ec-gpu-gen/opencl", "fs2", "blstrs/gpu"]
 groth16 = []
 # Wasm friendly build. Disable default features for this.
 wasm = [ "getrandom/js", "groth16" ]
@@ -89,3 +89,8 @@ members = [
 
 [build-dependencies]
 rustversion = "1.0.6"
+
+[patch.crates-io]
+ec-gpu = { git = "https://github.com/filecoin-project/ec-gpu", branch = "fft-no-gpuengine" }
+ec-gpu-gen = { git = "https://github.com/filecoin-project/ec-gpu", branch = "fft-no-gpuengine" }
+blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "ec-gpu-impl" }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -14,40 +14,39 @@
 #[cfg(any(feature = "cuda", feature = "opencl"))]
 use ec_gpu_gen::fft::FftKernel;
 use ff::{Field, PrimeField};
-use pairing::Engine;
 
 use super::SynthesisError;
 use crate::gpu;
 use ec_gpu_gen::fft_cpu;
 use ec_gpu_gen::threadpool::Worker;
 
-pub struct EvaluationDomain<E: Engine + gpu::GpuEngine> {
-    coeffs: Vec<E::Fr>,
+pub struct EvaluationDomain<F: PrimeField + gpu::GpuField> {
+    coeffs: Vec<F>,
     exp: u32,
-    omega: E::Fr,
-    omegainv: E::Fr,
-    geninv: E::Fr,
-    minv: E::Fr,
+    omega: F,
+    omegainv: F,
+    geninv: F,
+    minv: F,
 }
 
-impl<E: Engine + gpu::GpuEngine> AsRef<[E::Fr]> for EvaluationDomain<E> {
-    fn as_ref(&self) -> &[E::Fr] {
+impl<F: PrimeField + gpu::GpuField> AsRef<[F]> for EvaluationDomain<F> {
+    fn as_ref(&self) -> &[F] {
         &self.coeffs
     }
 }
 
-impl<E: Engine + gpu::GpuEngine> AsMut<[E::Fr]> for EvaluationDomain<E> {
-    fn as_mut(&mut self) -> &mut [E::Fr] {
+impl<F: PrimeField + gpu::GpuField> AsMut<[F]> for EvaluationDomain<F> {
+    fn as_mut(&mut self) -> &mut [F] {
         &mut self.coeffs
     }
 }
 
-impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
-    pub fn into_coeffs(self) -> Vec<E::Fr> {
+impl<F: PrimeField + gpu::GpuField> EvaluationDomain<F> {
+    pub fn into_coeffs(self) -> Vec<F> {
         self.coeffs
     }
 
-    pub fn from_coeffs(mut coeffs: Vec<E::Fr>) -> Result<EvaluationDomain<E>, SynthesisError> {
+    pub fn from_coeffs(mut coeffs: Vec<F>) -> Result<Self, SynthesisError> {
         // Compute the size of our evaluation domain
         let mut m = 1;
         let mut exp = 0;
@@ -57,35 +56,35 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
 
             // The pairing-friendly curve may not be able to support
             // large enough (radix2) evaluation domains.
-            if exp >= E::Fr::S {
+            if exp >= F::S {
                 return Err(SynthesisError::PolynomialDegreeTooLarge);
             }
         }
         // Compute omega, the 2^exp primitive root of unity
-        let mut omega = E::Fr::root_of_unity();
-        for _ in exp..E::Fr::S {
+        let mut omega = F::root_of_unity();
+        for _ in exp..F::S {
             omega = omega.square();
         }
 
         // Extend the coeffs vector with zeroes if necessary
-        coeffs.resize(m, E::Fr::zero());
+        coeffs.resize(m, F::zero());
 
         Ok(EvaluationDomain {
             coeffs,
             exp,
             omega,
             omegainv: omega.invert().unwrap(),
-            geninv: E::Fr::multiplicative_generator().invert().unwrap(),
-            minv: E::Fr::from(m as u64).invert().unwrap(),
+            geninv: F::multiplicative_generator().invert().unwrap(),
+            minv: F::from(m as u64).invert().unwrap(),
         })
     }
 
     pub fn fft(
         &mut self,
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
-        best_fft::<E>(
+        best_fft::<F>(
             kern,
             worker,
             &mut [&mut self.coeffs],
@@ -99,7 +98,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn fft_many(
         domains: &mut [&mut Self],
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         let (mut coeffs, rest): (Vec<_>, Vec<_>) = domains
             .iter_mut()
@@ -114,7 +113,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn ifft(
         &mut self,
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         Self::ifft_many(&mut [self], worker, kern)
     }
@@ -123,7 +122,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn ifft_many(
         domains: &mut [&mut Self],
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         let (mut coeffs, rest): (Vec<_>, Vec<_>) = domains
             .iter_mut()
@@ -150,7 +149,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
         Ok(())
     }
 
-    pub fn distribute_powers(&mut self, worker: &Worker, g: E::Fr) {
+    pub fn distribute_powers(&mut self, worker: &Worker, g: F) {
         worker.scope(self.coeffs.len(), |scope, chunk| {
             for (i, v) in self.coeffs.chunks_mut(chunk).enumerate() {
                 scope.execute(move || {
@@ -167,7 +166,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn coset_fft(
         &mut self,
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         Self::coset_fft_many(&mut [self], worker, kern)
     }
@@ -176,10 +175,10 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn coset_fft_many(
         domains: &mut [&mut Self],
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         for domain in domains.iter_mut() {
-            domain.distribute_powers(worker, E::Fr::multiplicative_generator());
+            domain.distribute_powers(worker, F::multiplicative_generator());
         }
 
         Self::fft_many(domains, worker, kern)?;
@@ -190,7 +189,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn icoset_fft(
         &mut self,
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         let geninv = self.geninv;
         self.ifft(worker, kern)?;
@@ -200,16 +199,16 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
 
     /// This evaluates t(tau) for this domain, which is
     /// tau^m - 1 for these radix-2 domains.
-    pub fn z(&self, tau: &E::Fr) -> E::Fr {
+    pub fn z(&self, tau: &F) -> F {
         let tmp = tau.pow_vartime(&[self.coeffs.len() as u64]);
-        tmp - E::Fr::one()
+        tmp - <F as Field>::one()
     }
 
     /// The target polynomial is the zero polynomial in our
     /// evaluation domain, so we must perform division over
     /// a coset.
     pub fn divide_by_z_on_coset(&mut self, worker: &Worker) {
-        let i = self.z(&E::Fr::multiplicative_generator()).invert().unwrap();
+        let i = self.z(&F::multiplicative_generator()).invert().unwrap();
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
             for v in self.coeffs.chunks_mut(chunk) {
@@ -223,7 +222,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     }
 
     /// Perform O(n) multiplication of two polynomials in the domain.
-    pub fn mul_assign(&mut self, worker: &Worker, other: &EvaluationDomain<E>) {
+    pub fn mul_assign(&mut self, worker: &Worker, other: &Self) {
         assert_eq!(self.coeffs.len(), other.coeffs.len());
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
@@ -242,7 +241,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     }
 
     /// Perform O(n) subtraction of one polynomial from another in the domain.
-    pub fn sub_assign(&mut self, worker: &Worker, other: &EvaluationDomain<E>) {
+    pub fn sub_assign(&mut self, worker: &Worker, other: &Self) {
         assert_eq!(self.coeffs.len(), other.coeffs.len());
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
@@ -261,17 +260,17 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     }
 }
 
-fn best_fft<E: Engine + gpu::GpuEngine>(
-    #[allow(unused_variables)] kern: &mut Option<gpu::LockedFFTKernel<E>>,
+fn best_fft<F: PrimeField + gpu::GpuField>(
+    #[allow(unused_variables)] kern: &mut Option<gpu::LockedFftKernel<F>>,
     worker: &Worker,
-    coeffs: &mut [&mut [E::Fr]],
-    omegas: &[E::Fr],
+    coeffs: &mut [&mut [F]],
+    omegas: &[F],
     log_ns: &[u32],
 ) {
     #[cfg(any(feature = "cuda", feature = "opencl"))]
     if let Some(ref mut kern) = kern {
         if kern
-            .with(|k: &mut FftKernel<E>| gpu_fft(k, coeffs, omegas, log_ns))
+            .with(|k: &mut FftKernel<F>| gpu_fft(k, coeffs, omegas, log_ns))
             .is_ok()
         {
             return;
@@ -281,18 +280,18 @@ fn best_fft<E: Engine + gpu::GpuEngine>(
     let log_cpus = worker.log_num_threads();
     for ((a, omega), log_n) in coeffs.iter_mut().zip(omegas.iter()).zip(log_ns.iter()) {
         if *log_n <= log_cpus {
-            fft_cpu::serial_fft::<E>(*a, omega, *log_n);
+            fft_cpu::serial_fft::<F>(*a, omega, *log_n);
         } else {
-            fft_cpu::parallel_fft::<E>(*a, worker, omega, *log_n, log_cpus);
+            fft_cpu::parallel_fft::<F>(*a, worker, omega, *log_n, log_cpus);
         }
     }
 }
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
-pub fn gpu_fft<E: Engine + gpu::GpuEngine>(
-    kern: &mut FftKernel<E>,
-    coeffs: &mut [&mut [E::Fr]],
-    omegas: &[E::Fr],
+pub fn gpu_fft<F: PrimeField + gpu::GpuField>(
+    kern: &mut FftKernel<F>,
+    coeffs: &mut [&mut [F]],
+    omegas: &[F],
     log_ns: &[u32],
 ) -> gpu::GpuResult<()> {
     Ok(kern.radix_fft_many(coeffs, omegas, log_ns)?)
@@ -302,34 +301,35 @@ pub fn gpu_fft<E: Engine + gpu::GpuEngine>(
 mod tests {
     use super::*;
 
+    use blstrs::Bls12;
+    use pairing::Engine;
+    use rand_core::RngCore;
+
     // Test multiplying various (low degree) polynomials together and
     // comparing with naive evaluations.
     #[test]
     fn polynomial_arith() {
-        use blstrs::Bls12;
-        use rand_core::RngCore;
-
-        fn test_mul<E: Engine + gpu::GpuEngine, R: RngCore>(rng: &mut R) {
+        fn test_mul<F: PrimeField + gpu::GpuField, R: RngCore>(rng: &mut R) {
             let worker = Worker::new();
 
             for coeffs_a in 0..70 {
                 for coeffs_b in 0..70 {
-                    let mut a: Vec<_> = (0..coeffs_a).map(|_| E::Fr::random(&mut *rng)).collect();
-                    let mut b: Vec<_> = (0..coeffs_b).map(|_| E::Fr::random(&mut *rng)).collect();
+                    let mut a: Vec<_> = (0..coeffs_a).map(|_| F::random(&mut *rng)).collect();
+                    let mut b: Vec<_> = (0..coeffs_b).map(|_| F::random(&mut *rng)).collect();
 
                     // naive evaluation
-                    let mut naive = vec![E::Fr::zero(); coeffs_a + coeffs_b];
+                    let mut naive = vec![F::zero(); coeffs_a + coeffs_b];
                     for (i1, a) in a.iter().enumerate() {
                         for (i2, b) in b.iter().enumerate() {
                             naive[i1 + i2] += *a * b;
                         }
                     }
 
-                    a.resize(coeffs_a + coeffs_b, E::Fr::zero());
-                    b.resize(coeffs_a + coeffs_b, E::Fr::zero());
+                    a.resize(coeffs_a + coeffs_b, F::zero());
+                    b.resize(coeffs_a + coeffs_b, F::zero());
 
-                    let mut a = EvaluationDomain::<E>::from_coeffs(a).unwrap();
-                    let mut b = EvaluationDomain::<E>::from_coeffs(b).unwrap();
+                    let mut a = EvaluationDomain::from_coeffs(a).unwrap();
+                    let mut b = EvaluationDomain::from_coeffs(b).unwrap();
 
                     a.fft(&worker, &mut None).unwrap();
                     b.fft(&worker, &mut None).unwrap();
@@ -345,16 +345,15 @@ mod tests {
 
         let rng = &mut rand::thread_rng();
 
-        test_mul::<Bls12, _>(rng);
+        test_mul::<<Bls12 as Engine>::Fr, _>(rng);
     }
 
     #[test]
     fn fft_composition() {
         use blstrs::Bls12;
-        use pairing::Engine;
         use rand_core::RngCore;
 
-        fn test_comp<E: Engine + gpu::GpuEngine, R: RngCore>(rng: &mut R) {
+        fn test_comp<F: PrimeField + gpu::GpuField, R: RngCore>(rng: &mut R) {
             let worker = Worker::new();
 
             for coeffs in 0..10 {
@@ -362,10 +361,10 @@ mod tests {
 
                 let mut v = vec![];
                 for _ in 0..coeffs {
-                    v.push(E::Fr::random(&mut *rng));
+                    v.push(F::random(&mut *rng));
                 }
 
-                let mut domain = EvaluationDomain::<E>::from_coeffs(v.clone()).unwrap();
+                let mut domain = EvaluationDomain::from_coeffs(v.clone()).unwrap();
                 domain.ifft(&worker, &mut None).unwrap();
                 domain.fft(&worker, &mut None).unwrap();
                 assert!(v == domain.coeffs);
@@ -383,6 +382,6 @@ mod tests {
 
         let rng = &mut rand::thread_rng();
 
-        test_comp::<Bls12, _>(rng);
+        test_comp::<<Bls12 as Engine>::Fr, _>(rng);
     }
 }

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -1,15 +1,15 @@
 use std::fs::File;
 use std::path::PathBuf;
 
-use ec_gpu::GpuEngine;
 use ec_gpu_gen::fft::FftKernel;
 use ec_gpu_gen::rust_gpu_tools::Device;
+use ff::Field;
 use fs2::FileExt;
+use group::prime::PrimeCurveAffine;
 use log::{debug, info, warn};
-use pairing::Engine;
 
 use crate::gpu::error::{GpuError, GpuResult};
-use crate::gpu::CpuGpuMultiexpKernel;
+use crate::gpu::{CpuGpuMultiexpKernel, GpuField, GpuName};
 
 const GPU_LOCK_NAME: &str = "bellman.gpu.lock";
 const PRIORITY_LOCK_NAME: &str = "bellman.priority.lock";
@@ -99,9 +99,9 @@ impl Drop for PriorityLock {
     }
 }
 
-fn create_fft_kernel<'a, E>(priority: bool) -> Option<FftKernel<'a, E>>
+fn create_fft_kernel<'a, F>(priority: bool) -> Option<FftKernel<'a, F>>
 where
-    E: Engine + GpuEngine,
+    F: Field + GpuField,
 {
     let devices = Device::all();
     let kernel = if priority {
@@ -125,9 +125,9 @@ where
     }
 }
 
-fn create_multiexp_kernel<'a, E>(priority: bool) -> Option<CpuGpuMultiexpKernel<'a, E>>
+fn create_multiexp_kernel<'a, G>(priority: bool) -> Option<CpuGpuMultiexpKernel<'a, G>>
 where
-    E: Engine + GpuEngine,
+    G: PrimeCurveAffine + GpuName,
 {
     let devices = Device::all();
     let kernel = if priority {
@@ -152,24 +152,29 @@ where
 }
 
 macro_rules! locked_kernel {
-    ($class:ident, $kern:ident, $func:ident, $name:expr) => {
-        #[allow(clippy::upper_case_acronyms)]
-        pub struct $class<'a, E>
-        where
-            E: pairing::Engine + ec_gpu::GpuEngine,
+    ($kernel:ty, $func:ident, $name:expr, pub struct $class:ident<$lifetime:lifetime, $generic:ident>
+        where $(
+            $bound:ty: $boundvalue:tt $(+ $morebounds:tt )*,
+        )+
+    ) => {
+        pub struct $class<$lifetime, $generic>
+        where $(
+            $bound : $boundvalue $(+ $morebounds)*,
+        )+
         {
             priority: bool,
             // Keep the GPU lock alongside the kernel, so that the lock is automatically dropped
             // if the kernel is dropped.
-            kernel_and_lock: Option<($kern<'a, E>, GPULock)>,
+            kernel_and_lock: Option<($kernel, GPULock)>,
         }
 
-        impl<'a, E> $class<'a, E>
-        where
-            E: pairing::Engine + ec_gpu::GpuEngine,
+        impl<'a, $generic> $class<$lifetime, $generic>
+        where $(
+            $bound: $boundvalue $(+ $morebounds)*,
+        )+
         {
-            pub fn new(priority: bool) -> $class<'a, E> {
-                $class::<E> {
+            pub fn new(priority: bool) -> Self {
+                Self {
                     priority,
                     kernel_and_lock: None,
                 }
@@ -182,7 +187,7 @@ macro_rules! locked_kernel {
                 if self.kernel_and_lock.is_none() {
                     PriorityLock::wait(self.priority);
                     info!("GPU is available for {}!", $name);
-                    if let Some(kernel) = $func::<E>(self.priority) {
+                    if let Some(kernel) = $func(self.priority) {
                         self.kernel_and_lock = Some((kernel, GPULock::lock()));
                     }
                 }
@@ -201,9 +206,9 @@ macro_rules! locked_kernel {
                 }
             }
 
-            pub fn with<F, R>(&mut self, mut f: F) -> GpuResult<R>
+            pub fn with<Fun, R>(&mut self, mut f: Fun) -> GpuResult<R>
             where
-                F: FnMut(&mut $kern<E>) -> GpuResult<R>,
+                Fun: FnMut(&mut $kernel) -> GpuResult<R>,
             {
                 if std::env::var("BELLMAN_NO_GPU").is_ok() {
                     return Err(GpuError::GpuDisabled);
@@ -234,10 +239,17 @@ macro_rules! locked_kernel {
     };
 }
 
-locked_kernel!(LockedFFTKernel, FftKernel, create_fft_kernel, "FFT");
 locked_kernel!(
-    LockedMultiexpKernel,
-    CpuGpuMultiexpKernel,
+    FftKernel<'a, F>,
+    create_fft_kernel,
+    "FFT",
+    pub struct LockedFftKernel<'a, F> where F: Field + GpuField,
+);
+locked_kernel!(
+    CpuGpuMultiexpKernel<'a, G>,
     create_multiexp_kernel,
-    "Multiexp"
+    "Multiexp",
+    pub struct LockedMultiexpKernel<'a, G>
+    where
+        G: PrimeCurveAffine + GpuName,
 );

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -20,9 +20,16 @@ mod nogpu;
 #[cfg(not(any(feature = "cuda", feature = "opencl")))]
 pub use self::nogpu::*;
 
+// This is a hack, so that the same traits can be used for the GPU and non-GPU code path.
 #[cfg(any(feature = "cuda", feature = "opencl"))]
-pub use ec_gpu::GpuEngine;
+pub use ec_gpu::{GpuField, GpuName};
 #[cfg(not(any(feature = "cuda", feature = "opencl")))]
-pub trait GpuEngine {}
+pub trait GpuField {}
 #[cfg(not(any(feature = "cuda", feature = "opencl")))]
-impl<E: pairing::Engine> GpuEngine for E {}
+pub trait GpuName {}
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
+impl GpuName for blstrs::G1Affine {}
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
+impl GpuName for blstrs::G2Affine {}
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
+impl GpuField for blstrs::Scalar {}

--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -10,9 +10,8 @@ use ec_gpu_gen::EcResult;
 use ff::PrimeField;
 use group::{prime::PrimeCurveAffine, Group};
 use log::{error, info};
-use pairing::Engine;
 
-use crate::gpu::GpuEngine;
+use crate::gpu::GpuName;
 
 pub fn get_cpu_utilization() -> f64 {
     env::var("BELLMAN_CPU_UTILIZATION")
@@ -54,13 +53,13 @@ fn set_custom_gpu_env_var() {
 }
 
 /// A Multiexp kernel that can share the workload between the GPU and the CPU.
-pub struct CpuGpuMultiexpKernel<'a, E>(MultiexpKernel<'a, E>)
+pub struct CpuGpuMultiexpKernel<'a, G>(MultiexpKernel<'a, G>)
 where
-    E: Engine + GpuEngine;
+    G: PrimeCurveAffine;
 
-impl<'a, E> CpuGpuMultiexpKernel<'a, E>
+impl<'a, G> CpuGpuMultiexpKernel<'a, G>
 where
-    E: Engine + GpuEngine,
+    G: PrimeCurveAffine + GpuName,
 {
     /// Create new kernels, one for each given device.
     pub fn create(devices: &[&Device]) -> EcResult<Self> {
@@ -85,16 +84,13 @@ where
     }
 
     /// Calculate multiexp.
-    pub fn multiexp<G>(
+    pub fn multiexp(
         &mut self,
         pool: &Worker,
         bases: Arc<Vec<G>>,
         exps: Arc<Vec<<G::Scalar as PrimeField>::Repr>>,
         skip: usize,
-    ) -> EcResult<<G as PrimeCurveAffine>::Curve>
-    where
-        G: PrimeCurveAffine<Scalar = E::Fr>,
-    {
+    ) -> EcResult<G::Curve> {
         // Bases are skipped by `self.1` elements, when converted from (Arc<Vec<G>>, usize) to Source
         // https://github.com/zkcrypto/bellman/blob/10c5010fd9c2ca69442dc9775ea271e286e776d8/src/multiexp.rs#L38
         let bases = &bases[skip..(skip + exps.len())];
@@ -110,12 +106,12 @@ where
 
         let cpu_acc = pool.scoped(|s| {
             if n > 0 {
-                results = vec![<G as PrimeCurveAffine>::Curve::identity(); self.0.num_kernels()];
+                results = vec![G::Curve::identity(); self.0.num_kernels()];
                 self.0
                     .parallel_multiexp(s, bases, exps, &mut results, error.clone());
             }
 
-            multiexp_cpu::<_, _, _, E, _>(
+            multiexp_cpu(
                 pool,
                 (Arc::new(cpu_bases.to_vec()), 0),
                 FullDensity,
@@ -127,7 +123,7 @@ where
             .expect("only one ref left")
             .into_inner()
             .unwrap()?;
-        let mut acc = <G as PrimeCurveAffine>::Curve::identity();
+        let mut acc = G::Curve::identity();
         for r in results {
             acc.add_assign(&r);
         }

--- a/src/gpu/nogpu.rs
+++ b/src/gpu/nogpu.rs
@@ -1,30 +1,32 @@
 use super::error::{GpuError, GpuResult};
 use ec_gpu_gen::threadpool::Worker;
-use ff::PrimeField;
+use ff::{Field, PrimeField};
 use group::prime::PrimeCurveAffine;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-pub struct MultiexpKernel<E>(PhantomData<E>)
-where
-    E: Engine;
+use crate::gpu::GpuField;
 
-impl<E> MultiexpKernel<E>
+pub struct MultiexpKernel<G>(PhantomData<G>)
 where
-    E: Engine,
+    G: PrimeCurveAffine;
+
+impl<G> MultiexpKernel<G>
+where
+    G: PrimeCurveAffine,
 {
     pub fn create(_: bool) -> GpuResult<Self> {
         Err(GpuError::GpuDisabled)
     }
 
-    pub fn multiexp<G>(
+    pub fn multiexp(
         &mut self,
         _: &Worker,
         _: Arc<Vec<G>>,
         _: Arc<Vec<<G::Scalar as PrimeField>::Repr>>,
         _: usize,
         _: usize,
-    ) -> GpuResult<<G as PrimeCurveAffine>::Curve>
+    ) -> GpuResult<G::Curve>
     where
         G: PrimeCurveAffine,
     {
@@ -32,24 +34,26 @@ where
     }
 }
 
-use pairing::Engine;
-
 macro_rules! locked_kernel {
-    ($class:ident) => {
-        #[allow(clippy::upper_case_acronyms)]
-        pub struct $class<E>(PhantomData<E>);
+    (pub struct $class:ident<$generic:ident>
+        where $(
+            $bound:ty: $boundvalue:tt $(+ $morebounds:tt )*,
+        )+
+    ) => {
+        pub struct $class<$generic>(PhantomData<$generic>);
 
-        impl<E> $class<E>
-        where
-            E: Engine,
+        impl<$generic> $class<$generic>
+        where $(
+            $bound: $boundvalue $(+ $morebounds)*,
+        )+
         {
-            pub fn new(_: bool) -> $class<E> {
-                $class::<E>(PhantomData)
+            pub fn new(_: bool) -> Self {
+                Self(PhantomData)
             }
 
-            pub fn with<F, R, K>(&mut self, _: F) -> GpuResult<R>
+            pub fn with<Fun, R, K>(&mut self, _: Fun) -> GpuResult<R>
             where
-                F: FnMut(&mut K) -> GpuResult<R>,
+                Fun: FnMut(&mut K) -> GpuResult<R>,
             {
                 return Err(GpuError::GpuDisabled);
             }
@@ -57,5 +61,9 @@ macro_rules! locked_kernel {
     };
 }
 
-locked_kernel!(LockedFFTKernel);
-locked_kernel!(LockedMultiexpKernel);
+locked_kernel!(pub struct LockedFftKernel<F> where F: Field + GpuField,);
+locked_kernel!(
+    pub struct LockedMultiexpKernel<G>
+    where
+        G: PrimeCurveAffine,
+);

--- a/src/groth16/ext.rs
+++ b/src/groth16/ext.rs
@@ -1,6 +1,7 @@
 use super::{create_proof_batch_priority, create_random_proof_batch_priority};
 use super::{ParameterSource, Proof};
 use crate::{gpu, Circuit, SynthesisError};
+use group::prime::PrimeCurveAffine;
 use pairing::MultiMillerLoop;
 use rand_core::RngCore;
 
@@ -11,8 +12,11 @@ pub fn create_proof<E, C, P: ParameterSource<E>>(
     s: E::Fr,
 ) -> Result<Proof<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: gpu::GpuField,
+    E::G1Affine: PrimeCurveAffine + gpu::GpuName,
+    E::G2Affine: PrimeCurveAffine + gpu::GpuName,
 {
     let proofs =
         create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], false)?;
@@ -25,9 +29,12 @@ pub fn create_random_proof<E, C, R, P: ParameterSource<E>>(
     rng: &mut R,
 ) -> Result<Proof<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
+    E::Fr: gpu::GpuField,
+    E::G1Affine: PrimeCurveAffine + gpu::GpuName,
+    E::G2Affine: PrimeCurveAffine + gpu::GpuName,
 {
     let proofs =
         create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, false)?;
@@ -41,8 +48,11 @@ pub fn create_proof_batch<E, C, P: ParameterSource<E>>(
     s: Vec<E::Fr>,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: gpu::GpuField,
+    E::G1Affine: PrimeCurveAffine + gpu::GpuName,
+    E::G2Affine: PrimeCurveAffine + gpu::GpuName,
 {
     create_proof_batch_priority::<E, C, P>(circuits, params, r, s, false)
 }
@@ -53,9 +63,12 @@ pub fn create_random_proof_batch<E, C, R, P: ParameterSource<E>>(
     rng: &mut R,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
+    E::Fr: gpu::GpuField,
+    E::G1Affine: PrimeCurveAffine + gpu::GpuName,
+    E::G2Affine: PrimeCurveAffine + gpu::GpuName,
 {
     create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, false)
 }
@@ -67,8 +80,11 @@ pub fn create_proof_in_priority<E, C, P: ParameterSource<E>>(
     s: E::Fr,
 ) -> Result<Proof<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: gpu::GpuField,
+    E::G1Affine: PrimeCurveAffine + gpu::GpuName,
+    E::G2Affine: PrimeCurveAffine + gpu::GpuName,
 {
     let proofs =
         create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], true)?;
@@ -81,9 +97,12 @@ pub fn create_random_proof_in_priority<E, C, R, P: ParameterSource<E>>(
     rng: &mut R,
 ) -> Result<Proof<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
+    E::Fr: gpu::GpuField,
+    E::G1Affine: PrimeCurveAffine + gpu::GpuName,
+    E::G2Affine: PrimeCurveAffine + gpu::GpuName,
 {
     let proofs =
         create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, true)?;
@@ -97,8 +116,11 @@ pub fn create_proof_batch_in_priority<E, C, P: ParameterSource<E>>(
     s: Vec<E::Fr>,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: gpu::GpuField,
+    E::G1Affine: PrimeCurveAffine + gpu::GpuName,
+    E::G2Affine: PrimeCurveAffine + gpu::GpuName,
 {
     create_proof_batch_priority::<E, C, P>(circuits, params, r, s, true)
 }
@@ -109,9 +131,12 @@ pub fn create_random_proof_batch_in_priority<E, C, R, P: ParameterSource<E>>(
     rng: &mut R,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
+    E::Fr: gpu::GpuField,
+    E::G1Affine: PrimeCurveAffine + gpu::GpuName,
+    E::G2Affine: PrimeCurveAffine + gpu::GpuName,
 {
     create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, true)
 }

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -23,11 +23,12 @@ pub fn generate_random_parameters<E, C, R>(
     rng: &mut R,
 ) -> Result<Parameters<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     <E as Engine>::G1: WnafGroup,
     <E as Engine>::G2: WnafGroup,
     C: Circuit<E::Fr>,
     R: RngCore,
+    E::Fr: gpu::GpuField,
 {
     let g1 = E::G1::random(&mut *rng);
     let g2 = E::G2::random(&mut *rng);
@@ -193,15 +194,16 @@ pub fn generate_parameters<E, C>(
     tau: E::Fr,
 ) -> Result<Parameters<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     <E as Engine>::G1: WnafGroup,
     <E as Engine>::G2: WnafGroup,
     C: Circuit<E::Fr>,
+    E::Fr: gpu::GpuField,
 {
     let mut assembly = KeypairAssembly::new();
 
     // Allocate the "one" input variable
-    assembly.alloc_input(|| "", || Ok(E::Fr::one()))?;
+    assembly.alloc_input(|| "", || Ok(<E::Fr as Field>::one()))?;
 
     // Synthesize the circuit.
     circuit.synthesize(&mut assembly)?;
@@ -214,7 +216,7 @@ where
 
     // Create bases for blind evaluation of polynomials at tau
     let powers_of_tau = vec![E::Fr::zero(); assembly.num_constraints];
-    let mut powers_of_tau = EvaluationDomain::<E>::from_coeffs(powers_of_tau)?;
+    let mut powers_of_tau = EvaluationDomain::from_coeffs(powers_of_tau)?;
 
     // Compute G1 window table
     let mut g1_wnaf = Wnaf::new();

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 
 use super::{ParameterSource, Proof};
 use crate::domain::EvaluationDomain;
-use crate::gpu::{GpuEngine, LockedFFTKernel, LockedMultiexpKernel};
+use crate::gpu::{GpuField, GpuName, LockedFftKernel, LockedMultiexpKernel};
 use crate::multiexp::multiexp;
 use crate::{
     Circuit, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable, BELLMAN_VERSION,
@@ -225,9 +225,12 @@ pub fn create_random_proof_batch_priority<E, C, R, P: ParameterSource<E>>(
     priority: bool,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
+    E::Fr: GpuField,
+    E::G1Affine: PrimeCurveAffine + GpuName,
+    E::G2Affine: PrimeCurveAffine + GpuName,
 {
     let r_s = (0..circuits.len())
         .map(|_| E::Fr::random(&mut *rng))
@@ -247,8 +250,11 @@ pub fn create_proof_batch_priority_nonzk<E, C, P: ParameterSource<E>>(
     priority: bool,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: GpuField,
+    E::G1Affine: PrimeCurveAffine + GpuName,
+    E::G2Affine: PrimeCurveAffine + GpuName,
 {
     create_proof_batch_priority_inner(circuits, params, None, priority)
 }
@@ -264,8 +270,11 @@ pub fn create_proof_batch_priority<E, C, P: ParameterSource<E>>(
     priority: bool,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: GpuField,
+    E::G1Affine: PrimeCurveAffine + GpuName,
+    E::G2Affine: PrimeCurveAffine + GpuName,
 {
     create_proof_batch_priority_inner(circuits, params, Some((r_s, s_s)), priority)
 }
@@ -279,8 +288,11 @@ fn create_proof_batch_priority_inner<E, C, P: ParameterSource<E>>(
     priority: bool,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: GpuField,
+    E::G1Affine: PrimeCurveAffine + GpuName,
+    E::G2Affine: PrimeCurveAffine + GpuName,
 {
     info!("Bellperson {} is being used!", BELLMAN_VERSION);
 
@@ -348,14 +360,14 @@ where
             *params_h = Some(params.get_h(n));
         });
 
-        let mut fft_kern = Some(LockedFFTKernel::<E>::new(priority));
+        let mut fft_kern = Some(LockedFftKernel::new(priority));
         for prover in provers_ref {
             a_s.push(execute_fft(worker, prover, &mut fft_kern)?);
         }
         Ok(())
     })?;
 
-    let mut multiexp_kern = LockedMultiexpKernel::<E>::new(priority);
+    let mut multiexp_g1_kern = LockedMultiexpKernel::<E::G1Affine>::new(priority);
     let params_h = params_h.unwrap()?;
 
     let mut h_s = Vec::with_capacity(num_circuits);
@@ -375,7 +387,7 @@ where
                 params_h.clone(),
                 FullDensity,
                 a,
-                &mut multiexp_kern,
+                &mut multiexp_g1_kern,
             ));
         }
     });
@@ -410,7 +422,7 @@ where
                 params_l.clone(),
                 FullDensity,
                 aux.clone(),
-                &mut multiexp_kern,
+                &mut multiexp_g1_kern,
             ));
         }
     });
@@ -449,7 +461,7 @@ where
                     a_inputs_source.clone(),
                     FullDensity,
                     input_assignment.clone(),
-                    &mut multiexp_kern,
+                    &mut multiexp_g1_kern,
                 );
 
                 let a_aux = multiexp(
@@ -457,7 +469,7 @@ where
                     a_aux_source.clone(),
                     a_aux_density.clone(),
                     aux_assignment.clone(),
-                    &mut multiexp_kern,
+                    &mut multiexp_g1_kern,
                 );
 
                 let b_g1_inputs_aux_opt =
@@ -470,14 +482,14 @@ where
                                     b_g1_inputs_source.clone(),
                                     b_input_density.clone(),
                                     input_assignment.clone(),
-                                    &mut multiexp_kern,
+                                    &mut multiexp_g1_kern,
                                 ),
                                 multiexp(
                                     worker,
                                     b_g1_aux_source.clone(),
                                     b_aux_density.clone(),
                                     aux_assignment.clone(),
-                                    &mut multiexp_kern,
+                                    &mut multiexp_g1_kern,
                                 ),
                             )
                         });
@@ -486,9 +498,14 @@ where
             },
         )
         .collect::<Vec<_>>();
+    drop(multiexp_g1_kern);
     drop(a_inputs_source);
     drop(a_aux_source);
     drop(params_b_g1_opt);
+
+    // The multiexp kernel for G1 can only be initiated after the kernel for G1 was dropped. Else
+    // it would block, trying to acquire the GPU lock.
+    let mut multiexp_g2_kern = LockedMultiexpKernel::<E::G2Affine>::new(priority);
 
     debug!("get b_g2");
     let (b_g2_inputs_source, b_g2_aux_source) = params_b_g2.unwrap()?;
@@ -505,21 +522,21 @@ where
                     b_g2_inputs_source.clone(),
                     b_input_density.clone(),
                     input_assignment.clone(),
-                    &mut multiexp_kern,
+                    &mut multiexp_g2_kern,
                 );
                 let b_g2_aux = multiexp(
                     worker,
                     b_g2_aux_source.clone(),
                     b_aux_density.clone(),
                     aux_assignment.clone(),
-                    &mut multiexp_kern,
+                    &mut multiexp_g2_kern,
                 );
 
                 (b_g2_inputs, b_g2_aux)
             },
         )
         .collect::<Vec<_>>();
-    drop(multiexp_kern);
+    drop(multiexp_g2_kern);
     drop(densities);
     drop(b_g2_inputs_source);
     drop(b_g2_aux_source);
@@ -594,13 +611,13 @@ where
     Ok(proofs)
 }
 
-fn execute_fft<E>(
+fn execute_fft<F>(
     worker: &Worker,
-    prover: &mut ProvingAssignment<E::Fr>,
-    fft_kern: &mut Option<LockedFFTKernel<E>>,
-) -> Result<Arc<Vec<<E::Fr as PrimeField>::Repr>>, SynthesisError>
+    prover: &mut ProvingAssignment<F>,
+    fft_kern: &mut Option<LockedFftKernel<F>>,
+) -> Result<Arc<Vec<F::Repr>>, SynthesisError>
 where
-    E: GpuEngine + MultiMillerLoop,
+    F: PrimeField + GpuField,
 {
     let mut a = EvaluationDomain::from_coeffs(std::mem::take(&mut prover.a))?;
     let mut b = EvaluationDomain::from_coeffs(std::mem::take(&mut prover.b))?;
@@ -718,14 +735,15 @@ mod tests {
 
                 let mut full_assignment = ProvingAssignment::<Fr>::new();
                 full_assignment
-                    .alloc_input(|| "one", || Ok(Fr::one()))
+                    .alloc_input(|| "one", || Ok(<Fr as Field>::one()))
                     .unwrap();
 
                 let mut partial_assignments = Vec::with_capacity(count / k);
                 for i in 0..count {
                     if i % k == 0 {
                         let mut p = ProvingAssignment::new();
-                        p.alloc_input(|| "one", || Ok(Fr::one())).unwrap();
+                        p.alloc_input(|| "one", || Ok(<Fr as Field>::one()))
+                            .unwrap();
                         partial_assignments.push(p)
                     }
 
@@ -756,7 +774,9 @@ mod tests {
                 }
 
                 let mut combined = ProvingAssignment::new();
-                combined.alloc_input(|| "one", || Ok(Fr::one())).unwrap();
+                combined
+                    .alloc_input(|| "one", || Ok(<Fr as Field>::one()))
+                    .unwrap();
 
                 for assignment in partial_assignments.into_iter() {
                     combined.extend(assignment);

--- a/src/groth16/tests/dummy_engine.rs
+++ b/src/groth16/tests/dummy_engine.rs
@@ -359,9 +359,10 @@ impl Engine for DummyEngine {
 }
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
-impl ec_gpu::GpuEngine for DummyEngine {
-    type Scalar = Fr;
-    type Fp = Fr;
+impl ec_gpu::GpuName for Fr {
+    fn name() -> String {
+        "dummy_fr".to_string()
+    }
 }
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
@@ -378,6 +379,12 @@ impl ec_gpu::GpuField for Fr {
         vec![MODULUS_R.0]
     }
 }
+
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
+impl crate::gpu::GpuName for Fr {}
+
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
+impl crate::gpu::GpuField for Fr {}
 
 impl MillerLoopResult for Fr {
     type Gt = Fr;


### PR DESCRIPTION
The FFT and Multiexp kernels operates on fields instead of an engine.
For Multiexp it means that for BLS12-381 we need two separate kernels,
one for G1 and one for G2.

Relies on https://github.com/filecoin-project/ec-gpu/pull/29.