### PR TITLE
fix: make it work with latest GPU kernels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ jobs:
       - *restore-workspace
       - *restore-cache
       - set-env-path
+      - install-gpu-deps
       - run:
           name: Run cargo clippy (default features)
           command: cargo clippy --all --all-targets -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+# NOTE vmx 2022-08-19: Using the `__private_bench` feature of `blstrs` is just temporarily until
+# https://github.com/zkcrypto/group/pull/29 is fixed. Then we won't need the exports of `Fp` and
+# `Fp2` any more.
 [package]
 name = "bellperson"
 authors = [
@@ -34,11 +37,11 @@ itertools = "0.10.0"
 bincode = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.9"
-blstrs = "0.5.0"
+blstrs = { version = "0.6.0", features = ["__private_bench"] }
 pairing = "0.22"
 yastl = "0.1.2"
-ec-gpu = { version = "0.1.0" }
-ec-gpu-gen = { version = "0.3.0", default-features = false, features = ["fft", "multiexp"] }
+ec-gpu = { version = "0.2.0" }
+ec-gpu-gen = { version = "0.4.0" }
 
 fs2 = { version = "0.4.3", optional = true }
 
@@ -88,4 +91,6 @@ members = [
 ]
 
 [build-dependencies]
+blstrs = { version = "0.6.0", features = ["__private_bench"] }
+ec-gpu-gen = { version = "0.4.0" }
 rustversion = "1.0.6"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 fn main() {
-    cfg_if_nightly()
+    cfg_if_nightly();
+    gpu_kernel();
 }
 
 #[rustversion::nightly]
@@ -9,3 +10,20 @@ fn cfg_if_nightly() {
 
 #[rustversion::not(nightly)]
 fn cfg_if_nightly() {}
+
+/// The build script is used to generate the CUDA kernel and OpenCL source at compile-time, if the
+/// `cuda` and/or `opencl` feature is enabled.
+#[cfg(any(feature = "cuda", feature = "opencl"))]
+fn gpu_kernel() {
+    use blstrs::{Fp, Fp2, G1Affine, G2Affine, Scalar};
+    use ec_gpu_gen::SourceBuilder;
+
+    let source_builder = SourceBuilder::new()
+        .add_fft::<Scalar>()
+        .add_multiexp::<G1Affine, Fp>()
+        .add_multiexp::<G2Affine, Fp2>();
+    ec_gpu_gen::generate(&source_builder);
+}
+
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
+fn gpu_kernel() {}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -14,40 +14,39 @@
 #[cfg(any(feature = "cuda", feature = "opencl"))]
 use ec_gpu_gen::fft::FftKernel;
 use ff::{Field, PrimeField};
-use pairing::Engine;
 
 use super::SynthesisError;
 use crate::gpu;
 use ec_gpu_gen::fft_cpu;
 use ec_gpu_gen::threadpool::Worker;
 
-pub struct EvaluationDomain<E: Engine + gpu::GpuEngine> {
-    coeffs: Vec<E::Fr>,
+pub struct EvaluationDomain<F: PrimeField + gpu::GpuName> {
+    coeffs: Vec<F>,
     exp: u32,
-    omega: E::Fr,
-    omegainv: E::Fr,
-    geninv: E::Fr,
-    minv: E::Fr,
+    omega: F,
+    omegainv: F,
+    geninv: F,
+    minv: F,
 }
 
-impl<E: Engine + gpu::GpuEngine> AsRef<[E::Fr]> for EvaluationDomain<E> {
-    fn as_ref(&self) -> &[E::Fr] {
+impl<F: PrimeField + gpu::GpuName> AsRef<[F]> for EvaluationDomain<F> {
+    fn as_ref(&self) -> &[F] {
         &self.coeffs
     }
 }
 
-impl<E: Engine + gpu::GpuEngine> AsMut<[E::Fr]> for EvaluationDomain<E> {
-    fn as_mut(&mut self) -> &mut [E::Fr] {
+impl<F: PrimeField + gpu::GpuName> AsMut<[F]> for EvaluationDomain<F> {
+    fn as_mut(&mut self) -> &mut [F] {
         &mut self.coeffs
     }
 }
 
-impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
-    pub fn into_coeffs(self) -> Vec<E::Fr> {
+impl<F: PrimeField + gpu::GpuName> EvaluationDomain<F> {
+    pub fn into_coeffs(self) -> Vec<F> {
         self.coeffs
     }
 
-    pub fn from_coeffs(mut coeffs: Vec<E::Fr>) -> Result<EvaluationDomain<E>, SynthesisError> {
+    pub fn from_coeffs(mut coeffs: Vec<F>) -> Result<Self, SynthesisError> {
         // Compute the size of our evaluation domain
         let mut m = 1;
         let mut exp = 0;
@@ -57,35 +56,35 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
 
             // The pairing-friendly curve may not be able to support
             // large enough (radix2) evaluation domains.
-            if exp >= E::Fr::S {
+            if exp >= F::S {
                 return Err(SynthesisError::PolynomialDegreeTooLarge);
             }
         }
         // Compute omega, the 2^exp primitive root of unity
-        let mut omega = E::Fr::root_of_unity();
-        for _ in exp..E::Fr::S {
+        let mut omega = F::root_of_unity();
+        for _ in exp..F::S {
             omega = omega.square();
         }
 
         // Extend the coeffs vector with zeroes if necessary
-        coeffs.resize(m, E::Fr::zero());
+        coeffs.resize(m, F::zero());
 
         Ok(EvaluationDomain {
             coeffs,
             exp,
             omega,
             omegainv: omega.invert().unwrap(),
-            geninv: E::Fr::multiplicative_generator().invert().unwrap(),
-            minv: E::Fr::from(m as u64).invert().unwrap(),
+            geninv: F::multiplicative_generator().invert().unwrap(),
+            minv: F::from(m as u64).invert().unwrap(),
         })
     }
 
     pub fn fft(
         &mut self,
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
-        best_fft::<E>(
+        best_fft::<F>(
             kern,
             worker,
             &mut [&mut self.coeffs],
@@ -99,7 +98,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn fft_many(
         domains: &mut [&mut Self],
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         let (mut coeffs, rest): (Vec<_>, Vec<_>) = domains
             .iter_mut()
@@ -114,7 +113,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn ifft(
         &mut self,
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         Self::ifft_many(&mut [self], worker, kern)
     }
@@ -123,7 +122,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn ifft_many(
         domains: &mut [&mut Self],
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         let (mut coeffs, rest): (Vec<_>, Vec<_>) = domains
             .iter_mut()
@@ -150,7 +149,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
         Ok(())
     }
 
-    pub fn distribute_powers(&mut self, worker: &Worker, g: E::Fr) {
+    pub fn distribute_powers(&mut self, worker: &Worker, g: F) {
         worker.scope(self.coeffs.len(), |scope, chunk| {
             for (i, v) in self.coeffs.chunks_mut(chunk).enumerate() {
                 scope.execute(move || {
@@ -167,7 +166,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn coset_fft(
         &mut self,
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         Self::coset_fft_many(&mut [self], worker, kern)
     }
@@ -176,10 +175,10 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn coset_fft_many(
         domains: &mut [&mut Self],
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         for domain in domains.iter_mut() {
-            domain.distribute_powers(worker, E::Fr::multiplicative_generator());
+            domain.distribute_powers(worker, F::multiplicative_generator());
         }
 
         Self::fft_many(domains, worker, kern)?;
@@ -190,7 +189,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     pub fn icoset_fft(
         &mut self,
         worker: &Worker,
-        kern: &mut Option<gpu::LockedFFTKernel<E>>,
+        kern: &mut Option<gpu::LockedFftKernel<F>>,
     ) -> gpu::GpuResult<()> {
         let geninv = self.geninv;
         self.ifft(worker, kern)?;
@@ -200,16 +199,16 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
 
     /// This evaluates t(tau) for this domain, which is
     /// tau^m - 1 for these radix-2 domains.
-    pub fn z(&self, tau: &E::Fr) -> E::Fr {
+    pub fn z(&self, tau: &F) -> F {
         let tmp = tau.pow_vartime(&[self.coeffs.len() as u64]);
-        tmp - E::Fr::one()
+        tmp - <F as Field>::one()
     }
 
     /// The target polynomial is the zero polynomial in our
     /// evaluation domain, so we must perform division over
     /// a coset.
     pub fn divide_by_z_on_coset(&mut self, worker: &Worker) {
-        let i = self.z(&E::Fr::multiplicative_generator()).invert().unwrap();
+        let i = self.z(&F::multiplicative_generator()).invert().unwrap();
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
             for v in self.coeffs.chunks_mut(chunk) {
@@ -223,7 +222,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     }
 
     /// Perform O(n) multiplication of two polynomials in the domain.
-    pub fn mul_assign(&mut self, worker: &Worker, other: &EvaluationDomain<E>) {
+    pub fn mul_assign(&mut self, worker: &Worker, other: &Self) {
         assert_eq!(self.coeffs.len(), other.coeffs.len());
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
@@ -242,7 +241,7 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     }
 
     /// Perform O(n) subtraction of one polynomial from another in the domain.
-    pub fn sub_assign(&mut self, worker: &Worker, other: &EvaluationDomain<E>) {
+    pub fn sub_assign(&mut self, worker: &Worker, other: &Self) {
         assert_eq!(self.coeffs.len(), other.coeffs.len());
 
         worker.scope(self.coeffs.len(), |scope, chunk| {
@@ -261,17 +260,17 @@ impl<E: Engine + gpu::GpuEngine> EvaluationDomain<E> {
     }
 }
 
-fn best_fft<E: Engine + gpu::GpuEngine>(
-    #[allow(unused_variables)] kern: &mut Option<gpu::LockedFFTKernel<E>>,
+fn best_fft<F: PrimeField + gpu::GpuName>(
+    #[allow(unused_variables)] kern: &mut Option<gpu::LockedFftKernel<F>>,
     worker: &Worker,
-    coeffs: &mut [&mut [E::Fr]],
-    omegas: &[E::Fr],
+    coeffs: &mut [&mut [F]],
+    omegas: &[F],
     log_ns: &[u32],
 ) {
     #[cfg(any(feature = "cuda", feature = "opencl"))]
     if let Some(ref mut kern) = kern {
         if kern
-            .with(|k: &mut FftKernel<E>| gpu_fft(k, coeffs, omegas, log_ns))
+            .with(|k: &mut FftKernel<F>| gpu_fft(k, coeffs, omegas, log_ns))
             .is_ok()
         {
             return;
@@ -281,18 +280,18 @@ fn best_fft<E: Engine + gpu::GpuEngine>(
     let log_cpus = worker.log_num_threads();
     for ((a, omega), log_n) in coeffs.iter_mut().zip(omegas.iter()).zip(log_ns.iter()) {
         if *log_n <= log_cpus {
-            fft_cpu::serial_fft::<E>(*a, omega, *log_n);
+            fft_cpu::serial_fft::<F>(*a, omega, *log_n);
         } else {
-            fft_cpu::parallel_fft::<E>(*a, worker, omega, *log_n, log_cpus);
+            fft_cpu::parallel_fft::<F>(*a, worker, omega, *log_n, log_cpus);
         }
     }
 }
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
-pub fn gpu_fft<E: Engine + gpu::GpuEngine>(
-    kern: &mut FftKernel<E>,
-    coeffs: &mut [&mut [E::Fr]],
-    omegas: &[E::Fr],
+pub fn gpu_fft<F: PrimeField + gpu::GpuName>(
+    kern: &mut FftKernel<F>,
+    coeffs: &mut [&mut [F]],
+    omegas: &[F],
     log_ns: &[u32],
 ) -> gpu::GpuResult<()> {
     Ok(kern.radix_fft_many(coeffs, omegas, log_ns)?)
@@ -302,34 +301,35 @@ pub fn gpu_fft<E: Engine + gpu::GpuEngine>(
 mod tests {
     use super::*;
 
+    use blstrs::Bls12;
+    use pairing::Engine;
+    use rand_core::RngCore;
+
     // Test multiplying various (low degree) polynomials together and
     // comparing with naive evaluations.
     #[test]
     fn polynomial_arith() {
-        use blstrs::Bls12;
-        use rand_core::RngCore;
-
-        fn test_mul<E: Engine + gpu::GpuEngine, R: RngCore>(rng: &mut R) {
+        fn test_mul<F: PrimeField + gpu::GpuName, R: RngCore>(rng: &mut R) {
             let worker = Worker::new();
 
             for coeffs_a in 0..70 {
                 for coeffs_b in 0..70 {
-                    let mut a: Vec<_> = (0..coeffs_a).map(|_| E::Fr::random(&mut *rng)).collect();
-                    let mut b: Vec<_> = (0..coeffs_b).map(|_| E::Fr::random(&mut *rng)).collect();
+                    let mut a: Vec<_> = (0..coeffs_a).map(|_| F::random(&mut *rng)).collect();
+                    let mut b: Vec<_> = (0..coeffs_b).map(|_| F::random(&mut *rng)).collect();
 
                     // naive evaluation
-                    let mut naive = vec![E::Fr::zero(); coeffs_a + coeffs_b];
+                    let mut naive = vec![F::zero(); coeffs_a + coeffs_b];
                     for (i1, a) in a.iter().enumerate() {
                         for (i2, b) in b.iter().enumerate() {
                             naive[i1 + i2] += *a * b;
                         }
                     }
 
-                    a.resize(coeffs_a + coeffs_b, E::Fr::zero());
-                    b.resize(coeffs_a + coeffs_b, E::Fr::zero());
+                    a.resize(coeffs_a + coeffs_b, F::zero());
+                    b.resize(coeffs_a + coeffs_b, F::zero());
 
-                    let mut a = EvaluationDomain::<E>::from_coeffs(a).unwrap();
-                    let mut b = EvaluationDomain::<E>::from_coeffs(b).unwrap();
+                    let mut a = EvaluationDomain::from_coeffs(a).unwrap();
+                    let mut b = EvaluationDomain::from_coeffs(b).unwrap();
 
                     a.fft(&worker, &mut None).unwrap();
                     b.fft(&worker, &mut None).unwrap();
@@ -345,16 +345,15 @@ mod tests {
 
         let rng = &mut rand::thread_rng();
 
-        test_mul::<Bls12, _>(rng);
+        test_mul::<<Bls12 as Engine>::Fr, _>(rng);
     }
 
     #[test]
     fn fft_composition() {
         use blstrs::Bls12;
-        use pairing::Engine;
         use rand_core::RngCore;
 
-        fn test_comp<E: Engine + gpu::GpuEngine, R: RngCore>(rng: &mut R) {
+        fn test_comp<F: PrimeField + gpu::GpuName, R: RngCore>(rng: &mut R) {
             let worker = Worker::new();
 
             for coeffs in 0..10 {
@@ -362,10 +361,10 @@ mod tests {
 
                 let mut v = vec![];
                 for _ in 0..coeffs {
-                    v.push(E::Fr::random(&mut *rng));
+                    v.push(F::random(&mut *rng));
                 }
 
-                let mut domain = EvaluationDomain::<E>::from_coeffs(v.clone()).unwrap();
+                let mut domain = EvaluationDomain::from_coeffs(v.clone()).unwrap();
                 domain.ifft(&worker, &mut None).unwrap();
                 domain.fft(&worker, &mut None).unwrap();
                 assert!(v == domain.coeffs);
@@ -383,6 +382,6 @@ mod tests {
 
         let rng = &mut rand::thread_rng();
 
-        test_comp::<Bls12, _>(rng);
+        test_comp::<<Bls12 as Engine>::Fr, _>(rng);
     }
 }

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -20,9 +20,14 @@ mod nogpu;
 #[cfg(not(any(feature = "cuda", feature = "opencl")))]
 pub use self::nogpu::*;
 
+// This is a hack, so that the same traits can be used for the GPU and non-GPU code path.
 #[cfg(any(feature = "cuda", feature = "opencl"))]
-pub use ec_gpu::GpuEngine;
+pub use ec_gpu::GpuName;
 #[cfg(not(any(feature = "cuda", feature = "opencl")))]
-pub trait GpuEngine {}
+pub trait GpuName {}
 #[cfg(not(any(feature = "cuda", feature = "opencl")))]
-impl<E: pairing::Engine> GpuEngine for E {}
+impl GpuName for blstrs::G1Affine {}
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
+impl GpuName for blstrs::G2Affine {}
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
+impl GpuName for blstrs::Scalar {}

--- a/src/groth16/ext.rs
+++ b/src/groth16/ext.rs
@@ -11,8 +11,11 @@ pub fn create_proof<E, C, P: ParameterSource<E>>(
     s: E::Fr,
 ) -> Result<Proof<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: gpu::GpuName,
+    E::G1Affine: gpu::GpuName,
+    E::G2Affine: gpu::GpuName,
 {
     let proofs =
         create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], false)?;
@@ -25,9 +28,12 @@ pub fn create_random_proof<E, C, R, P: ParameterSource<E>>(
     rng: &mut R,
 ) -> Result<Proof<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
+    E::Fr: gpu::GpuName,
+    E::G1Affine: gpu::GpuName,
+    E::G2Affine: gpu::GpuName,
 {
     let proofs =
         create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, false)?;
@@ -41,8 +47,11 @@ pub fn create_proof_batch<E, C, P: ParameterSource<E>>(
     s: Vec<E::Fr>,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: gpu::GpuName,
+    E::G1Affine: gpu::GpuName,
+    E::G2Affine: gpu::GpuName,
 {
     create_proof_batch_priority::<E, C, P>(circuits, params, r, s, false)
 }
@@ -53,9 +62,12 @@ pub fn create_random_proof_batch<E, C, R, P: ParameterSource<E>>(
     rng: &mut R,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
+    E::Fr: gpu::GpuName,
+    E::G1Affine: gpu::GpuName,
+    E::G2Affine: gpu::GpuName,
 {
     create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, false)
 }
@@ -67,8 +79,11 @@ pub fn create_proof_in_priority<E, C, P: ParameterSource<E>>(
     s: E::Fr,
 ) -> Result<Proof<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: gpu::GpuName,
+    E::G1Affine: gpu::GpuName,
+    E::G2Affine: gpu::GpuName,
 {
     let proofs =
         create_proof_batch_priority::<E, C, P>(vec![circuit], params, vec![r], vec![s], true)?;
@@ -81,9 +96,12 @@ pub fn create_random_proof_in_priority<E, C, R, P: ParameterSource<E>>(
     rng: &mut R,
 ) -> Result<Proof<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
+    E::Fr: gpu::GpuName,
+    E::G1Affine: gpu::GpuName,
+    E::G2Affine: gpu::GpuName,
 {
     let proofs =
         create_random_proof_batch_priority::<E, C, R, P>(vec![circuit], params, rng, true)?;
@@ -97,8 +115,11 @@ pub fn create_proof_batch_in_priority<E, C, P: ParameterSource<E>>(
     s: Vec<E::Fr>,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
+    E::Fr: gpu::GpuName,
+    E::G1Affine: gpu::GpuName,
+    E::G2Affine: gpu::GpuName,
 {
     create_proof_batch_priority::<E, C, P>(circuits, params, r, s, true)
 }
@@ -109,9 +130,12 @@ pub fn create_random_proof_batch_in_priority<E, C, R, P: ParameterSource<E>>(
     rng: &mut R,
 ) -> Result<Vec<Proof<E>>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     C: Circuit<E::Fr> + Send,
     R: RngCore,
+    E::Fr: gpu::GpuName,
+    E::G1Affine: gpu::GpuName,
+    E::G2Affine: gpu::GpuName,
 {
     create_random_proof_batch_priority::<E, C, R, P>(circuits, params, rng, true)
 }

--- a/src/groth16/generator.rs
+++ b/src/groth16/generator.rs
@@ -23,11 +23,12 @@ pub fn generate_random_parameters<E, C, R>(
     rng: &mut R,
 ) -> Result<Parameters<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     <E as Engine>::G1: WnafGroup,
     <E as Engine>::G2: WnafGroup,
     C: Circuit<E::Fr>,
     R: RngCore,
+    E::Fr: gpu::GpuName,
 {
     let g1 = E::G1::random(&mut *rng);
     let g2 = E::G2::random(&mut *rng);
@@ -193,15 +194,16 @@ pub fn generate_parameters<E, C>(
     tau: E::Fr,
 ) -> Result<Parameters<E>, SynthesisError>
 where
-    E: gpu::GpuEngine + MultiMillerLoop,
+    E: MultiMillerLoop,
     <E as Engine>::G1: WnafGroup,
     <E as Engine>::G2: WnafGroup,
     C: Circuit<E::Fr>,
+    E::Fr: gpu::GpuName,
 {
     let mut assembly = KeypairAssembly::new();
 
     // Allocate the "one" input variable
-    assembly.alloc_input(|| "", || Ok(E::Fr::one()))?;
+    assembly.alloc_input(|| "", || Ok(<E::Fr as Field>::one()))?;
 
     // Synthesize the circuit.
     circuit.synthesize(&mut assembly)?;
@@ -214,7 +216,7 @@ where
 
     // Create bases for blind evaluation of polynomials at tau
     let powers_of_tau = vec![E::Fr::zero(); assembly.num_constraints];
-    let mut powers_of_tau = EvaluationDomain::<E>::from_coeffs(powers_of_tau)?;
+    let mut powers_of_tau = EvaluationDomain::from_coeffs(powers_of_tau)?;
 
     // Compute G1 window table
     let mut g1_wnaf = Wnaf::new();

--- a/src/groth16/tests/dummy_engine.rs
+++ b/src/groth16/tests/dummy_engine.rs
@@ -359,25 +359,14 @@ impl Engine for DummyEngine {
 }
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
-impl ec_gpu::GpuEngine for DummyEngine {
-    type Scalar = Fr;
-    type Fp = Fr;
-}
-
-#[cfg(any(feature = "cuda", feature = "opencl"))]
-impl ec_gpu::GpuField for Fr {
-    fn one() -> Vec<u32> {
-        vec![R]
-    }
-
-    fn r2() -> Vec<u32> {
-        vec![R2]
-    }
-
-    fn modulus() -> Vec<u32> {
-        vec![MODULUS_R.0]
+impl ec_gpu::GpuName for Fr {
+    fn name() -> String {
+        "dummy_fr".to_string()
     }
 }
+
+#[cfg(not(any(feature = "cuda", feature = "opencl")))]
+impl crate::gpu::GpuName for Fr {}
 
 impl MillerLoopResult for Fr {
     type Gt = Fr;

--- a/verifier-bench/Cargo.toml
+++ b/verifier-bench/Cargo.toml
@@ -15,7 +15,7 @@ rand = "0.8"
 sha2 = "0.9"
 bincode = "1.3.1"
 pairing = "0.22"
-blstrs = "0.5.0"
+blstrs = "0.6.0"
 
 [features]
 default = ["groth16"]


### PR DESCRIPTION
The FFT and Multiexp kernels operates on fields instead of an engine.
For Multiexp it means that for BLS12-381 we need two separate kernels,
one for G1 and one for G2.

The kernel generation is no longer set via feature flags in `ec-gpu-gen`,
but instead it is directly specified in this library in the `build.rs`.

BREAKING CHANGE: upgrade to blstrs 0.6.0

`blstrs` version 0.6.0 is pinned to `blst` 0.3.10. All dependencies
need to be at the same version. Hence doing a breaking change release
is needed.