### PR TITLE
Bellperson Release v0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/bellperson"
 homepage = "https://github.com/filecoin-project/bellman"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/filecoin-project/bellman"
-version = "0.22.0"
+version = "0.23.0"
 readme = "README.md"
 edition = "2018"
 

--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,3 @@
 pre-release-commit-message = "chore({{crate_name}}): release {{version}}"
-pro-release-commit-message = "chore({{crate_name}}): starting development cycle for {{next_version}}"
-no-dev-version = true
+post-release-commit-message = "chore({{crate_name}}): starting development cycle for {{next_version}}"
+dev-version = false

--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,0 @@
-pre-release-commit-message = "chore({{crate_name}}): release {{version}}"
-post-release-commit-message = "chore({{crate_name}}): starting development cycle for {{next_version}}"
-dev-version = false


### PR DESCRIPTION
Cargo-release had two parameter name changes which need to be updated in order to publish the new release. 
pro-release-commit-message => post-release-commit-message
no-dev-version => dev-version