### PR TITLE
fix: remove wasm feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/filecoin-project/bellman"
 version = "0.23.0"
 readme = "README.md"
 edition = "2018"
+resolver = "2"
 
 [dependencies]
 bitvec = "0.22"
@@ -24,11 +25,9 @@ group = "0.12.0"
 rand_core = "0.6"
 byteorder = "1"
 log = "0.4.8"
-getrandom = { version = "0.2.5", optional = true }
 lazy_static = "1.4.0"
-rand = "0.8"
+rand = { version = "0.8", default-features = false }
 rayon = "1.5.0"
-memmap = { version = "0.7.0", optional = true }
 thiserror = "1.0.10"
 num_cpus = "1"
 crossbeam-channel = "0.5.0"
@@ -45,6 +44,9 @@ ec-gpu-gen = { version = "0.4.0" }
 
 fs2 = { version = "0.4.3", optional = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+memmap = "0.7.0"
+
 [dev-dependencies]
 hex-literal = "0.3"
 rand_xorshift = "0.3"
@@ -55,14 +57,13 @@ csv = "1.1.5"
 tempfile = "3.1.0"
 subtle = "2.2.1"
 temp-env = "0.2.0"
+rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 
 [features]
-default = ["groth16", "memmap" ]
+default = ["groth16"]
 cuda = ["ec-gpu-gen/cuda", "fs2", "blstrs/gpu"]
 opencl = ["ec-gpu-gen/opencl", "fs2", "blstrs/gpu"]
 groth16 = []
-# Wasm friendly build. Disable default features for this.
-wasm = [ "getrandom/js", "groth16" ]
 
 # This feature disables/modifies long running tests to make the suitable for code coverage
 # reporting

--- a/src/groth16/aggregate/srs.rs
+++ b/src/groth16/aggregate/srs.rs
@@ -8,14 +8,14 @@ use group::{
     prime::{PrimeCurve, PrimeCurveAffine},
     Curve, Group, GroupEncoding,
 };
-#[cfg(feature = "memmap")]
+#[cfg(not(target_arch = "wasm32"))]
 use memmap::Mmap;
 use pairing::Engine;
 use rayon::prelude::*;
 use sha2::Sha256;
 use std::convert::TryFrom;
 use std::io::{self, Error, ErrorKind, Read, Write};
-#[cfg(feature = "memmap")]
+#[cfg(not(target_arch = "wasm32"))]
 use std::mem::size_of;
 use std::ops::MulAssign;
 
@@ -273,7 +273,7 @@ where
         })
     }
 
-    #[cfg(feature = "memmap")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn read_mmap(reader: &Mmap, max_len: usize) -> io::Result<Self> {
         fn read_length(mmap: &Mmap, offset: &mut usize) -> Result<usize, std::io::Error> {
             let u32_len = size_of::<u32>();

--- a/src/groth16/mapped_params.rs
+++ b/src/groth16/mapped_params.rs
@@ -3,7 +3,7 @@ use pairing::MultiMillerLoop;
 
 use crate::SynthesisError;
 
-#[cfg(feature = "memmap")]
+#[cfg(not(target_arch = "wasm32"))]
 use memmap::Mmap;
 use rayon::prelude::*;
 

--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -10,7 +10,7 @@ mod tests;
 pub mod aggregate;
 mod ext;
 mod generator;
-#[cfg(feature = "memmap")]
+#[cfg(not(target_arch = "wasm32"))]
 mod mapped_params;
 mod params;
 mod proof;
@@ -22,7 +22,7 @@ mod multiscalar;
 
 pub use self::ext::*;
 pub use self::generator::*;
-#[cfg(feature = "memmap")]
+#[cfg(not(target_arch = "wasm32"))]
 pub use self::mapped_params::*;
 pub use self::params::*;
 pub use self::proof::*;

--- a/src/groth16/params.rs
+++ b/src/groth16/params.rs
@@ -6,7 +6,7 @@ use ec_gpu_gen::multiexp_cpu::SourceBuilder;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
-#[cfg(feature = "memmap")]
+#[cfg(not(target_arch = "wasm32"))]
 mod memmap_uses {
     pub use crate::groth16::MappedParameters;
     pub use memmap::{Mmap, MmapOptions};
@@ -18,7 +18,7 @@ mod memmap_uses {
 use std::io::{self, Read, Write};
 use std::sync::Arc;
 
-#[cfg(feature = "memmap")]
+#[cfg(not(target_arch = "wasm32"))]
 use memmap_uses::*;
 
 use super::VerifyingKey;
@@ -103,7 +103,7 @@ where
     // Quickly iterates through the parameter file, recording all
     // parameter offsets and caches the verifying key (vk) for quick
     // access via reference.
-    #[cfg(feature = "memmap")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn build_mapped_parameters(
         param_file_path: PathBuf,
         checked: bool,
@@ -178,7 +178,7 @@ where
     // advantageous to use (can be called by read_cached_params in
     // rust-fil-proofs repo).  It's equivalent to the existing read
     // method, in that it loads all parameters to RAM.
-    #[cfg(feature = "memmap")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn read_mmap(mmap: &Mmap, checked: bool) -> io::Result<Self> {
         let u32_len = mem::size_of::<u32>();
         let g1_len = mem::size_of::<<E::G1Affine as UncompressedEncoding>::Uncompressed>();

--- a/src/groth16/verifying_key.rs
+++ b/src/groth16/verifying_key.rs
@@ -2,10 +2,10 @@ use group::{prime::PrimeCurveAffine, UncompressedEncoding};
 use pairing::{Engine, MultiMillerLoop};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-#[cfg(feature = "memmap")]
+#[cfg(not(target_arch = "wasm32"))]
 use memmap::Mmap;
 use std::io::{self, Read, Write};
-#[cfg(feature = "memmap")]
+#[cfg(not(target_arch = "wasm32"))]
 use std::mem;
 
 use super::multiscalar;
@@ -120,7 +120,7 @@ impl<E: Engine + MultiMillerLoop> VerifyingKey<E> {
         })
     }
 
-    #[cfg(feature = "memmap")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn read_mmap(mmap: &Mmap, offset: &mut usize) -> io::Result<Self> {
         let u32_len = mem::size_of::<u32>();
         let g1_len = mem::size_of::<<E::G1Affine as UncompressedEncoding>::Uncompressed>();


### PR DESCRIPTION
The `wasm` feature was introduced as `getrandom` needs the `js` feature
in order to compile for `wasm32-unknown-unknown`. A better fix is to disable
the default features of `rand` instead. This way the `wasm` feature is no
longer needed.

For compiling on WebAssembly also the `memmap` feature was introduced. Remove
that feature and replace it with target architecture flags, that exclude
memmap related functions when compiled for wasm.

This lowers the maintenance burden as WebAssembly is no longer a special case.

Thanks @samuelburnham for the code that made the removal of `memmap` feature
possible.

BREAKING CHANGE: `wasm` and `memmap` features are removed

If you're targetting WASM and using `bellperson` as a dependency, prior to this
change you'd have included it as:

    bellperson = { version = "0.23", default-features = false, features = ["wasm"] }

Now you can instead just rely on the default features:

    bellperson = "0.23"

BREAKING CHANGE: resolver v2 is used

In order to make things compile nicely for the wasm target, the resolver was changed
to version 2.

---

This should be merged once we decide that we want to do a new breaking change version.