### PR TITLE
fix: upgrade bitvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-bitvec = "0.22"
 blake2s_simd = "0.5"
 ff = "0.12.0"
 group = "0.12.0"
@@ -40,7 +39,7 @@ blstrs = { version = "0.6.0", features = ["__private_bench"] }
 pairing = "0.22"
 yastl = "0.1.2"
 ec-gpu = { version = "0.2.0" }
-ec-gpu-gen = { version = "0.4.0" }
+ec-gpu-gen = { version = "0.5.0" }
 
 fs2 = { version = "0.4.3", optional = true }
 
@@ -93,5 +92,5 @@ members = [
 
 [build-dependencies]
 blstrs = { version = "0.6.0", features = ["__private_bench"] }
-ec-gpu-gen = { version = "0.4.0" }
+ec-gpu-gen = { version = "0.5.0" }
 rustversion = "1.0.6"


### PR DESCRIPTION
bitvec 0.22 does no longer build, due to funty 1.2 being yanked. bitvec wasn't actually used directly by this library anymore. Upgrade to ec-gpu-gen 0.5 which is using bitvec 1.0.1.