### PR TITLE
fix: make sure bitvec v1.0.1 is used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-bitvec = "0.22"
 blake2s_simd = "0.5"
 ff = "0.12.0"
 group = "0.12.0"
@@ -38,7 +37,7 @@ blstrs = "0.5.0"
 pairing = "0.22"
 yastl = "0.1.2"
 ec-gpu = { version = "0.1.0" }
-ec-gpu-gen = { version = "0.3.0", default-features = false, features = ["fft", "multiexp"] }
+ec-gpu-gen = { version = "0.3.1", default-features = false, features = ["fft", "multiexp"] }
 
 fs2 = { version = "0.4.3", optional = true }
 


### PR DESCRIPTION
This update is needed as bitvec 0.22.3 is requiring funty 1.2 which was yanked.

`bitvec` isn't a direct dependency of bellperson anymore. The upgrade to `ec-gpu-gen` v0.3.1 is done, as it;s the bugfix release that upgrades its `bitvec` from v0.22 to v1.0.1.