### PR TITLE
fix: make priority locking work again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ sha2 = "0.10.6"
 blstrs = { version = "0.6.0", features = ["__private_bench"] }
 pairing = "0.22"
 ec-gpu = { version = "0.2.0" }
-ec-gpu-gen = { version = "0.5.0" }
+ec-gpu-gen = { version = "0.5.1" }
 
 fs2 = { version = "0.4.3", optional = true }
 

--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -5,9 +5,6 @@ pub enum GpuError {
     #[error("GPUError: {0}")]
     Simple(&'static str),
     #[cfg(any(feature = "cuda", feature = "opencl"))]
-    #[error("GPU taken by a high priority process!")]
-    GpuTaken,
-    #[cfg(any(feature = "cuda", feature = "opencl"))]
     #[error("No kernel is initialized!")]
     KernelUninitialized,
     #[error("EC GPU error: {0}")]

--- a/tests/gpu_provers.rs
+++ b/tests/gpu_provers.rs
@@ -76,7 +76,7 @@ pub fn test_parallel_prover() {
     let pvk2 = prepare_verifying_key(&params2.vk);
 
     let higher_thread = thread::spawn(move || {
-        for _ in 0..10 {
+        for _ in 0..20 {
             let now = Instant::now();
 
             let rng = &mut thread_rng();
@@ -90,12 +90,12 @@ pub fn test_parallel_prover() {
             );
 
             // Sleep in between higher proofs so that LOWER thread can acquire GPU again
-            thread::sleep(Duration::from_millis(3000));
+            thread::sleep(Duration::from_millis(600));
         }
     });
 
     // Start lower proofs after a few seconds
-    thread::sleep(Duration::from_millis(10000));
+    thread::sleep(Duration::from_millis(2000));
     println!("Starting low priority proof gen...");
     {
         for _ in 0..10 {


### PR DESCRIPTION
Due to refactorings, the `PriorityLock::should_break()` logic was quite confusing and used the wrong way. Make it work correctly while simplifying the logic.

This commit also removes `PriorityLock` from the public API as it isn't really needed.

Tweak some values in the parallel prover test, so that aborting a low priority kernel from running on the GPU happens more frequently.

It needs a newer version of `ec-gpu-gen`, else it would cause panics
(which are not fatal, as they happen within a thread. Though, they
still show up in the logs).

Fixes #291.