### PR TITLE
Support to lock GPU for each task according to GPU_PER_TASK environment

### DIFF
--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -1,68 +1,44 @@
 use std::fs::File;
 use std::path::PathBuf;
-use std::convert::TryFrom;
 
-use ec_gpu::GpuEngine;
 use ec_gpu_gen::fft::FftKernel;
-use ec_gpu_gen::rust_gpu_tools::{Device, UniqueId};
+use ec_gpu_gen::rust_gpu_tools::Device;
+use ec_gpu_gen::EcError;
+use ff::Field;
 use fs2::FileExt;
+use group::prime::PrimeCurveAffine;
 use log::{debug, info, warn};
-use pairing::Engine;
 
 use crate::gpu::error::{GpuError, GpuResult};
-use crate::gpu::CpuGpuMultiexpKernel;
+use crate::gpu::{CpuGpuMultiexpKernel, GpuName};
 
 const GPU_LOCK_NAME: &str = "bellman.gpu.lock";
 const PRIORITY_LOCK_NAME: &str = "bellman.priority.lock";
-const PRIORITY_LOCK_UID: &str = "00000000-0000-0000-0000-000000000000";
-
-fn tmp_path(filename: &str, id: UniqueId) -> PathBuf {
+fn tmp_path(filename: &str) -> PathBuf {
     let mut p = std::env::temp_dir();
-    p.push(filename.to_owned() + "." + &id.to_string());
+    p.push(filename);
     p
 }
 
 /// `GPULock` prevents two kernel objects to be instantiated simultaneously.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug)]
-pub struct GPULock<'a>(Vec<(File, &'a Device, PathBuf)>);
-
-impl GPULock<'_> {
-    pub fn lock() -> GPULock<'static> {
-        let devices = Device::all();
-        let mut locks = Vec::new();
-
-        let mut gpu_per_task = match std::env::var("GPU_PER_TASK") {
-            Ok(val) => val.parse::<usize>().expect("GPU_PER_TASK must be number!"),
-            Err(_) => devices.len(),
-        };
-        if gpu_per_task == 0 {
-            gpu_per_task = devices.len();
-        }
-
-        for device in devices {
-            let uid = device.unique_id();
-            let gpu_lock_file = tmp_path(GPU_LOCK_NAME, uid);
-            debug!("Acquiring GPU {:?} lock at {:?} ...", uid, &gpu_lock_file);
-            let f = File::create(&gpu_lock_file)
-                .unwrap_or_else(|_| panic!("Cannot create GPU {:?} lock file at {:?}", uid, &gpu_lock_file));
-            f.lock_exclusive().unwrap();
-            debug!("GPU {:?} lock acquired!", uid);
-            locks.push((f, device, gpu_lock_file));
-            if locks.len() >= gpu_per_task {
-                break;
-            }
-        }
-
-        GPULock(locks)
+pub struct GPULock(File);
+impl GPULock {
+    pub fn lock() -> GPULock {
+        let gpu_lock_file = tmp_path(GPU_LOCK_NAME);
+        debug!("Acquiring GPU lock at {:?} ...", &gpu_lock_file);
+        let f = File::create(&gpu_lock_file)
+            .unwrap_or_else(|_| panic!("Cannot create GPU lock file at {:?}", &gpu_lock_file));
+        f.lock_exclusive().unwrap();
+        debug!("GPU lock acquired!");
+        GPULock(f)
     }
 }
-impl Drop for GPULock<'_> {
+impl Drop for GPULock {
     fn drop(&mut self) {
-        for f in &self.0 {
-            f.0.unlock().unwrap();
-            debug!("GPU {:?} lock released!", f.2);
-        }
+        self.0.unlock().unwrap();
+        debug!("GPU lock released!");
     }
 }
 
@@ -71,10 +47,10 @@ impl Drop for GPULock<'_> {
 /// signaling all other processes to release their `GPULock`s.
 /// Only one process can have the `PriorityLock` at a time.
 #[derive(Debug)]
-pub struct PriorityLock(File);
+pub(crate) struct PriorityLock(File);
 impl PriorityLock {
     pub fn lock() -> PriorityLock {
-        let priority_lock_file = tmp_path(PRIORITY_LOCK_NAME, UniqueId::try_from(PRIORITY_LOCK_UID).unwrap());
+        let priority_lock_file = tmp_path(PRIORITY_LOCK_NAME);
         debug!("Acquiring priority lock at {:?} ...", &priority_lock_file);
         let f = File::create(&priority_lock_file).unwrap_or_else(|_| {
             panic!(
@@ -87,9 +63,9 @@ impl PriorityLock {
         PriorityLock(f)
     }
 
-    pub fn wait(priority: bool) {
+    fn wait(priority: bool) {
         if !priority {
-            if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME, UniqueId::try_from(PRIORITY_LOCK_UID).unwrap()))
+            if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME))
                 .unwrap()
                 .lock_exclusive()
             {
@@ -98,20 +74,21 @@ impl PriorityLock {
         }
     }
 
-    pub fn should_break(priority: bool) -> bool {
-        if priority {
-            return false;
-        }
-        if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME, UniqueId::try_from(PRIORITY_LOCK_UID).unwrap()))
+    /// Returns true if the priority lock is currently taken.
+    ///
+    /// This is used by low priority proofs to determine whether to run on the GPU or not.
+    ///
+    /// It also returns `false` in case the state of the lock cannot be determined.
+    fn is_taken() -> bool {
+        if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME))
             .unwrap()
             .try_lock_shared()
         {
             // Check that the error is actually a locking one
             if err.raw_os_error() == fs2::lock_contended_error().raw_os_error() {
                 return true;
-            } else {
-                warn!("failed to check lock: {:?}", err);
             }
+            warn!("failed to check lock: {:?}", err);
         }
         false
     }
@@ -124,30 +101,27 @@ impl Drop for PriorityLock {
     }
 }
 
-fn create_fft_kernel<'a, E>(priority: bool) -> Option<(FftKernel<'a, E>, GPULock<'a>)>
+fn create_fft_kernel<'a, F>(priority: bool) -> Option<FftKernel<'a, F>>
 where
-    E: Engine + GpuEngine,
+    F: Field + GpuName,
 {
-    let lock = GPULock::lock();
-    let mut devices = Vec::new();
-
-    for l in &lock.0 {
-        devices.push(l.1);
-    }
+    let devices = Device::all();
+    let programs = devices
+        .iter()
+        .map(|device| ec_gpu_gen::program!(device))
+        .collect::<Result<_, _>>()
+        .ok()?;
 
     let kernel = if priority {
-        FftKernel::create_with_abort(&devices[..], &|| -> bool {
-            // We only supply a function in case it is high priority, hence always passing in
-            // `true`.
-            PriorityLock::should_break(true)
-        })
+        FftKernel::create(programs)
     } else {
-        FftKernel::create(&devices[..])
+        // Low priority kernels may be aborted if a high priority kernel wants to run/is running.
+        FftKernel::create_with_abort(programs, &PriorityLock::is_taken)
     };
     match kernel {
         Ok(k) => {
             info!("GPU FFT kernel instantiated!");
-            Some((k, lock))
+            Some(k)
         }
         Err(e) => {
             warn!("Cannot instantiate GPU FFT kernel! Error: {}", e);
@@ -156,30 +130,21 @@ where
     }
 }
 
-fn create_multiexp_kernel<'a, E>(priority: bool) -> Option<(CpuGpuMultiexpKernel<'a, E>, GPULock<'a>)>
+fn create_multiexp_kernel<'a, G>(priority: bool) -> Option<CpuGpuMultiexpKernel<'a, G>>
 where
-    E: Engine + GpuEngine,
+    G: PrimeCurveAffine + GpuName,
 {
-    let lock = GPULock::lock();
-    let mut devices = Vec::new();
-
-    for l in &lock.0 {
-        devices.push(l.1);
-    }
-
+    let devices = Device::all();
     let kernel = if priority {
-        CpuGpuMultiexpKernel::create_with_abort(&devices[..], &|| -> bool {
-            // We only supply a function in case it is high priority, hence always passing in
-            // `true`.
-            PriorityLock::should_break(true)
-        })
+        CpuGpuMultiexpKernel::create(&devices)
     } else {
-        CpuGpuMultiexpKernel::create(&devices[..])
+        // Low priority kernels may be aborted if a high priority kernel wants to run/is running.
+        CpuGpuMultiexpKernel::create_with_abort(&devices, &PriorityLock::is_taken)
     };
     match kernel {
         Ok(k) => {
             info!("GPU Multiexp kernel instantiated!");
-            Some((k, lock))
+            Some(k)
         }
         Err(e) => {
             warn!("Cannot instantiate GPU Multiexp kernel! Error: {}", e);
@@ -188,25 +153,31 @@ where
     }
 }
 
+/// Wrap the kernel so that only a single one runs on the GPU at a time.
 macro_rules! locked_kernel {
-    ($class:ident, $kern:ident, $func:ident, $name:expr) => {
-        #[allow(clippy::upper_case_acronyms)]
-        pub struct $class<'a, E>
-        where
-            E: pairing::Engine + ec_gpu::GpuEngine,
+    ($kernel:ty, $func:ident, $name:expr, pub struct $class:ident<$lifetime:lifetime, $generic:ident>
+        where $(
+            $bound:ty: $boundvalue:tt $(+ $morebounds:tt )*,
+        )+
+    ) => {
+        pub struct $class<$lifetime, $generic>
+        where $(
+            $bound : $boundvalue $(+ $morebounds)*,
+        )+
         {
             priority: bool,
             // Keep the GPU lock alongside the kernel, so that the lock is automatically dropped
             // if the kernel is dropped.
-            kernel_and_lock: Option<($kern<'a, E>, GPULock<'a>)>,
+            kernel_and_lock: Option<($kernel, GPULock)>,
         }
 
-        impl<'a, E> $class<'a, E>
-        where
-            E: pairing::Engine + ec_gpu::GpuEngine,
+        impl<'a, $generic> $class<$lifetime, $generic>
+        where $(
+            $bound: $boundvalue $(+ $morebounds)*,
+        )+
         {
-            pub fn new(priority: bool) -> $class<'a, E> {
-                $class::<E> {
+            pub fn new(priority: bool) -> Self {
+                Self {
                     priority,
                     kernel_and_lock: None,
                 }
@@ -219,8 +190,8 @@ macro_rules! locked_kernel {
                 if self.kernel_and_lock.is_none() {
                     PriorityLock::wait(self.priority);
                     info!("GPU is available for {}!", $name);
-                    if let Some((kernel, lock)) = $func::<E>(self.priority) {
-                        self.kernel_and_lock = Some((kernel, lock));
+                    if let Some(kernel) = $func(self.priority) {
+                        self.kernel_and_lock = Some((kernel, GPULock::lock()));
                     }
                 }
             }
@@ -238,9 +209,13 @@ macro_rules! locked_kernel {
                 }
             }
 
-            pub fn with<F, R>(&mut self, mut f: F) -> GpuResult<R>
+            /// Execute a function with the kernel.
+            ///
+            /// This function makes sure that only one things is run on the GPU at a time. It will
+            /// block until the GPU is available.
+            pub fn with<Fun, R>(&mut self, mut f: Fun) -> GpuResult<R>
             where
-                F: FnMut(&mut $kern<E>) -> GpuResult<R>,
+                Fun: FnMut(&mut $kernel) -> GpuResult<R>,
             {
                 if std::env::var("BELLMAN_NO_GPU").is_ok() {
                     return Err(GpuError::GpuDisabled);
@@ -253,7 +228,7 @@ macro_rules! locked_kernel {
                         match f(k) {
                             // Re-trying to run on the GPU is the core of this loop, all other
                             // cases abort the loop.
-                            Err(GpuError::GpuTaken) => {
+                            Err(GpuError::EcGpu(EcError::Aborted)) => {
                                 self.free();
                             }
                             Err(e) => {
@@ -271,10 +246,17 @@ macro_rules! locked_kernel {
     };
 }
 
-locked_kernel!(LockedFFTKernel, FftKernel, create_fft_kernel, "FFT");
 locked_kernel!(
-    LockedMultiexpKernel,
-    CpuGpuMultiexpKernel,
+    FftKernel<'a, F>,
+    create_fft_kernel,
+    "FFT",
+    pub struct LockedFftKernel<'a, F> where F: Field + GpuName,
+);
+locked_kernel!(
+    CpuGpuMultiexpKernel<'a, G>,
     create_multiexp_kernel,
-    "Multiexp"
+    "Multiexp",
+    pub struct LockedMultiexpKernel<'a, G>
+    where
+        G: PrimeCurveAffine + GpuName,
 );


### PR DESCRIPTION
original implementation lock bellman.gpu.lock to lock all GPUs in default. And in my test with cuda
single 3080 for C2: 15m52s
double 3080 for C2: 12m36s
so i think it's better to let user to choice if they need to use all GPUs for one C2 task.
a environment named GPU_PER_TASK is introduced to let user to set.
if GPU_PER_TASK is not set, then we use all GPUs for one C2, just like current implementation;
if GPU_PER_TASK == 0, just like above;
if GPU_PER_TASK > 0, use GPU_PER_TASK GPUs (up to devices.len()) for one C2 task.