### PR TITLE
Support to lock GPUs for each task according to BELLPERSON_GPUS_PER_LOCK environment (circleci of #298 not work properly, so i re-create this one)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,21 +63,21 @@ The gpu extension contains some env vars that may be set externally to this libr
 
 - `RAYON_NUM_THREADS`
 
-   Restricts the number of threads used in the library to roughly that number (best effort). In the past this was done using `BELLMAN_NUM_CPUS` which is now deprecated. The default is set to the number of logical cores reported on the machine.
+    Restricts the number of threads used in the library to roughly that number (best effort). In the past this was done using `BELLMAN_NUM_CPUS` which is now deprecated. The default is set to the number of logical cores reported on the machine.
 
-   ```rust
+    ```rust
     // Example
     env::set_var("RAYON_NUM_THREADS", "6");
-   ```
+    ```
 
  - `EC_GPU_NUM_THREADS`
 
-   Restricts the number of threads used by the FFT and multiexponentiation calculations. In the past this setting was shared with `RAYON_NUM_THREADS`, now they are separate settings that can be controlled independently. The default is set to the number of logical cores reported on the machine.
+    Restricts the number of threads used by the FFT and multiexponentiation calculations. In the past this setting was shared with `RAYON_NUM_THREADS`, now they are separate settings that can be controlled independently. The default is set to the number of logical cores reported on the machine.
 
-   ```rust
+    ```rust
     // Example
     env::set_var("EC_GPU_NUM_THREADS", "6");
-   ```
+    ```
 
  - `BELLMAN_GPU_FRAMEWORK`
 
@@ -97,6 +97,18 @@ The gpu extension contains some env vars that may be set externally to this libr
     env::set_var("BELLMAN_CUDA_NVCC_ARGS", "--fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75");
     ```
 
+ - `BELLPERSON_GPUS_PER_LOCK`
+
+    Restricts the number of devices used by the FFT and multiexponentiation calculations.
+    - If it's not set, single lock will be created, and each calculation use all devices
+    - If BELLPERSON_GPUS_PER_LOCK = 0, no lock will be created, each calculation use all devices, and each device can run multiple calculations
+    - If BELLPERSON_GPUS_PER_LOCK > 0, create a lock for each device, each calculation use BELLPERSON_GPUS_PER_LOCK (up to device number) devices
+
+    ```rust
+    // Example
+    env::set_var("BELLPERSON_GPUS_PER_LOCK", "0");
+    env::set_var("BELLPERSON_GPUS_PER_LOCK", "1");
+    ```
 
 #### Supported / Tested Cards
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The gpu extension contains some env vars that may be set externally to this libr
 
     Restricts the number of devices used by the FFT and multiexponentiation calculations.
     - If it's not set, a single lock will be created, and each calculation uses all devices
-    - If BELLPERSON_GPUS_PER_LOCK = 0, no lock will be created, each calculation uses all devices, and each device can run multiple calculations
+    - If BELLPERSON_GPUS_PER_LOCK = 0, no lock will be created, each calculation uses all devices, and each device can run multiple calculations. **WARNING**: this option can break things easily. Each kernel expects that it's run without anything else running on the GPU at the same time. If two kernels run at the same time, they might interfere with each other and lead to crashes or wrong results.
     - If BELLPERSON_GPUS_PER_LOCK > 0, create a lock for each device, each calculation uses BELLPERSON_GPUS_PER_LOCK (up to device number) devices
 
     ```rust

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -16,13 +16,11 @@ const GPU_LOCK_NAME: &str = "bellman.gpu.lock";
 const PRIORITY_LOCK_NAME: &str = "bellman.priority.lock";
 
 fn tmp_path(filename: &str, id: Option<UniqueId>) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    let mut tmpfile = filename.to_owned();
-    if let Some(id_str) = id {
-        tmpfile.push_str(&(".".to_owned() + &id_str.to_string()));
-    }
-    p.push(tmpfile);
-    p
+    let temp_file = match id {
+        Some(id) => format!("{}.{}", filename, id),
+        None => filename.to_string(),
+    };
+    std::env::temp_dir().join(temp_file)
 }
 
 /// Information about a lock.

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -49,11 +49,18 @@ impl GPULock<'_> {
         for (index, device) in devices.iter().enumerate() {
             let uid = device.unique_id();
             let gpu_lock_file = tmp_path(GPU_LOCK_NAME, Some(uid));
-            debug!("Acquiring GPU lock {}/{} at {:?} ...", index, gpus_per_lock, &gpu_lock_file);
-            let f = File::create(&gpu_lock_file)
-                .unwrap_or_else(|_| panic!("Cannot create GPU {:?} lock file at {:?}", uid, &gpu_lock_file));
+            debug!(
+                "Acquiring GPU lock {}/{} at {:?} ...",
+                index, gpus_per_lock, &gpu_lock_file,
+            );
+            let f = File::create(&gpu_lock_file).unwrap_or_else(|_| {
+                panic!(
+                    "Cannot create GPU {:?} lock file at {:?}",
+                    uid, &gpu_lock_file,
+                )
+            });
             if f.try_lock_exclusive().is_err() {
-                continue
+                continue;
             }
             debug!("GPU lock acquired at {:?}", gpu_lock_file);
             locks.push((f, *device, gpu_lock_file));
@@ -139,11 +146,11 @@ where
     F: Field + GpuName,
 {
     let lock = GPULock::lock();
-    let devices = lock.
-        0.
-        iter().
-        map(|(_, device, _)| *device).
-        collect::<Vec<&Device>>();
+    let devices = lock
+        .0
+        .iter()
+        .map(|(_, device, _)| *device)
+        .collect::<Vec<&Device>>();
 
     let programs = devices
         .iter()
@@ -176,11 +183,11 @@ where
     G: PrimeCurveAffine + GpuName,
 {
     let lock = GPULock::lock();
-    let devices = lock.
-        0.
-        iter().
-        map(|(_, device, _)| *device).
-        collect::<Vec<&Device>>();
+    let devices = lock
+        .0
+        .iter()
+        .map(|(_, device, _)| *device)
+        .collect::<Vec<&Device>>();
 
     let kernel = if priority {
         CpuGpuMultiexpKernel::create(&devices)
@@ -307,4 +314,3 @@ locked_kernel!(
     where
         G: PrimeCurveAffine + GpuName,
 );
-

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -297,3 +297,4 @@ locked_kernel!(
     where
         G: PrimeCurveAffine + GpuName,
 );
+

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -299,3 +299,4 @@ locked_kernel!(
     where
         G: PrimeCurveAffine + GpuName,
 );
+

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -47,7 +47,9 @@ impl GPULock<'_> {
             debug!("Acquiring GPU {:?} lock at {:?} ...", uid, &gpu_lock_file);
             let f = File::create(&gpu_lock_file)
                 .unwrap_or_else(|_| panic!("Cannot create GPU {:?} lock file at {:?}", uid, &gpu_lock_file));
-            f.lock_exclusive().unwrap();
+            if f.try_lock_exclusive().is_err() {
+                continue
+            }
             debug!("GPU {:?} lock acquired!", uid);
             locks.push((f, device, gpu_lock_file));
             if locks.len() >= gpu_per_task {

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 use std::path::PathBuf;
-use std::convert::TryFrom;
 
 use ec_gpu_gen::fft::FftKernel;
 use ec_gpu_gen::rust_gpu_tools::{Device, UniqueId};

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -42,7 +42,7 @@ impl GPULock<'_> {
                     Ok(val) if val > 0 => gpus_per_lock = val,
                     _ => warn!("BELLPERSON_GPUS_PER_LOCK is not number, use all gpus"),
                 };
-            },
+            }
             _ => warn!("BELLPERSON_GPUS_PER_LOCK parse fail, use all gpus"),
         };
 
@@ -139,7 +139,11 @@ where
     F: Field + GpuName,
 {
     let lock = GPULock::lock();
-    let devices = lock.0.iter().map(|(_, device, _)| *device).collect::<Vec<&Device>>();
+    let devices = lock.
+        0.
+        iter().
+        map(|(_, device, _)| *device).
+        collect::<Vec<&Device>>();
 
     let programs = devices
         .iter()
@@ -165,12 +169,18 @@ where
     }
 }
 
-fn create_multiexp_kernel<'a, G>(priority: bool) -> Option<(CpuGpuMultiexpKernel<'a, G>, GPULock<'a>)>
+fn create_multiexp_kernel<'a, G>(
+    priority: bool,
+) -> Option<(CpuGpuMultiexpKernel<'a, G>, GPULock<'a>)>
 where
     G: PrimeCurveAffine + GpuName,
 {
     let lock = GPULock::lock();
-    let devices = lock.0.iter().map(|(_, device, _)| *device).collect::<Vec<&Device>>();
+    let devices = lock.
+        0.
+        iter().
+        map(|(_, device, _)| *device).
+        collect::<Vec<&Device>>();
 
     let kernel = if priority {
         CpuGpuMultiexpKernel::create(&devices)

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -18,8 +18,8 @@ const PRIORITY_LOCK_NAME: &str = "bellman.priority.lock";
 fn tmp_path(filename: &str, id: Option<UniqueId>) -> PathBuf {
     let mut p = std::env::temp_dir();
     let mut tmpfile = filename.to_owned();
-    if id.is_some() {
-        tmpfile.push_str(&(".".to_owned() + &id.unwrap().to_string()));
+    if let Some(id_str) = id {
+        tmpfile.push_str(&(".".to_owned() + &id_str.to_string()));
     }
     p.push(tmpfile);
     p

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -297,4 +297,3 @@ locked_kernel!(
     where
         G: PrimeCurveAffine + GpuName,
 );
-

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -1,68 +1,44 @@
 use std::fs::File;
 use std::path::PathBuf;
-use std::convert::TryFrom;
 
-use ec_gpu::GpuEngine;
 use ec_gpu_gen::fft::FftKernel;
-use ec_gpu_gen::rust_gpu_tools::{Device, UniqueId};
+use ec_gpu_gen::rust_gpu_tools::Device;
+use ec_gpu_gen::EcError;
+use ff::Field;
 use fs2::FileExt;
+use group::prime::PrimeCurveAffine;
 use log::{debug, info, warn};
-use pairing::Engine;
 
 use crate::gpu::error::{GpuError, GpuResult};
-use crate::gpu::CpuGpuMultiexpKernel;
+use crate::gpu::{CpuGpuMultiexpKernel, GpuName};
 
 const GPU_LOCK_NAME: &str = "bellman.gpu.lock";
 const PRIORITY_LOCK_NAME: &str = "bellman.priority.lock";
-const PRIORITY_LOCK_UID: &str = "00000000-0000-0000-0000-000000000000";
-
-fn tmp_path(filename: &str, id: UniqueId) -> PathBuf {
+fn tmp_path(filename: &str) -> PathBuf {
     let mut p = std::env::temp_dir();
-    p.push(filename.to_owned() + "." + &id.to_string());
+    p.push(filename);
     p
 }
 
 /// `GPULock` prevents two kernel objects to be instantiated simultaneously.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug)]
-pub struct GPULock<'a>(Vec<(File, &'a Device, PathBuf)>);
-
-impl GPULock<'_> {
-    pub fn lock() -> GPULock<'static> {
-        let devices = Device::all();
-        let mut locks = Vec::new();
-
-        let mut gpu_per_task = match std::env::var("GPU_PER_TASK") {
-            Ok(val) => val.parse::<usize>().expect("GPU_PER_TASK must be number!"),
-            Err(_) => devices.len(),
-        };
-        if gpu_per_task == 0 {
-            gpu_per_task = devices.len();
-        }
-
-        for device in devices {
-            let uid = device.unique_id();
-            let gpu_lock_file = tmp_path(GPU_LOCK_NAME, uid);
-            debug!("Acquiring GPU {:?} lock at {:?} ...", uid, &gpu_lock_file);
-            let f = File::create(&gpu_lock_file)
-                .unwrap_or_else(|_| panic!("Cannot create GPU {:?} lock file at {:?}", uid, &gpu_lock_file));
-            f.lock_exclusive().unwrap();
-            debug!("GPU {:?} lock acquired!", uid);
-            locks.push((f, device, gpu_lock_file));
-            if locks.len() >= gpu_per_task {
-                break;
-            }
-        }
-
-        GPULock(locks)
+pub struct GPULock(File);
+impl GPULock {
+    pub fn lock() -> GPULock {
+        let gpu_lock_file = tmp_path(GPU_LOCK_NAME);
+        debug!("Acquiring GPU lock at {:?} ...", &gpu_lock_file);
+        let f = File::create(&gpu_lock_file)
+            .unwrap_or_else(|_| panic!("Cannot create GPU lock file at {:?}", &gpu_lock_file));
+        f.lock_exclusive().unwrap();
+        debug!("GPU lock acquired!");
+        GPULock(f)
     }
 }
-impl Drop for GPULock<'_> {
+impl Drop for GPULock {
     fn drop(&mut self) {
-        for f in &self.0 {
-            f.0.unlock().unwrap();
-            debug!("GPU {:?} lock released!", f.2);
-        }
+        self.0.unlock().unwrap();
+        debug!("GPU lock released!");
     }
 }
 
@@ -71,10 +47,10 @@ impl Drop for GPULock<'_> {
 /// signaling all other processes to release their `GPULock`s.
 /// Only one process can have the `PriorityLock` at a time.
 #[derive(Debug)]
-pub struct PriorityLock(File);
+pub(crate) struct PriorityLock(File);
 impl PriorityLock {
     pub fn lock() -> PriorityLock {
-        let priority_lock_file = tmp_path(PRIORITY_LOCK_NAME, UniqueId::try_from(PRIORITY_LOCK_UID).unwrap());
+        let priority_lock_file = tmp_path(PRIORITY_LOCK_NAME);
         debug!("Acquiring priority lock at {:?} ...", &priority_lock_file);
         let f = File::create(&priority_lock_file).unwrap_or_else(|_| {
             panic!(
@@ -87,9 +63,9 @@ impl PriorityLock {
         PriorityLock(f)
     }
 
-    pub fn wait(priority: bool) {
+    fn wait(priority: bool) {
         if !priority {
-            if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME, UniqueId::try_from(PRIORITY_LOCK_UID).unwrap()))
+            if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME))
                 .unwrap()
                 .lock_exclusive()
             {
@@ -98,20 +74,21 @@ impl PriorityLock {
         }
     }
 
-    pub fn should_break(priority: bool) -> bool {
-        if priority {
-            return false;
-        }
-        if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME, UniqueId::try_from(PRIORITY_LOCK_UID).unwrap()))
+    /// Returns true if the priority lock is currently taken.
+    ///
+    /// This is used by low priority proofs to determine whether to run on the GPU or not.
+    ///
+    /// It also returns `false` in case the state of the lock cannot be determined.
+    fn is_taken() -> bool {
+        if let Err(err) = File::create(tmp_path(PRIORITY_LOCK_NAME))
             .unwrap()
             .try_lock_shared()
         {
             // Check that the error is actually a locking one
             if err.raw_os_error() == fs2::lock_contended_error().raw_os_error() {
                 return true;
-            } else {
-                warn!("failed to check lock: {:?}", err);
             }
+            warn!("failed to check lock: {:?}", err);
         }
         false
     }
@@ -124,30 +101,27 @@ impl Drop for PriorityLock {
     }
 }
 
-fn create_fft_kernel<'a, E>(priority: bool) -> Option<(FftKernel<'a, E>, GPULock<'a>)>
+fn create_fft_kernel<'a, F>(priority: bool) -> Option<FftKernel<'a, F>>
 where
-    E: Engine + GpuEngine,
+    F: Field + GpuName,
 {
-    let lock = GPULock::lock();
-    let mut devices = Vec::new();
-
-    for l in &lock.0 {
-        devices.push(l.1);
-    }
+    let devices = Device::all();
+    let programs = devices
+        .iter()
+        .map(|device| ec_gpu_gen::program!(device))
+        .collect::<Result<_, _>>()
+        .ok()?;
 
     let kernel = if priority {
-        FftKernel::create_with_abort(&devices[..], &|| -> bool {
-            // We only supply a function in case it is high priority, hence always passing in
-            // `true`.
-            PriorityLock::should_break(true)
-        })
+        FftKernel::create(programs)
     } else {
-        FftKernel::create(&devices[..])
+        // Low priority kernels may be aborted if a high priority kernel wants to run/is running.
+        FftKernel::create_with_abort(programs, &PriorityLock::is_taken)
     };
     match kernel {
         Ok(k) => {
             info!("GPU FFT kernel instantiated!");
-            Some((k, lock))
+            Some(k)
         }
         Err(e) => {
             warn!("Cannot instantiate GPU FFT kernel! Error: {}", e);
@@ -156,30 +130,21 @@ where
     }
 }
 
-fn create_multiexp_kernel<'a, E>(priority: bool) -> Option<(CpuGpuMultiexpKernel<'a, E>, GPULock<'a>)>
+fn create_multiexp_kernel<'a, G>(priority: bool) -> Option<CpuGpuMultiexpKernel<'a, G>>
 where
-    E: Engine + GpuEngine,
+    G: PrimeCurveAffine + GpuName,
 {
-    let lock = GPULock::lock();
-    let mut devices = Vec::new();
-
-    for l in &lock.0 {
-        devices.push(l.1);
-    }
-
+    let devices = Device::all();
     let kernel = if priority {
-        CpuGpuMultiexpKernel::create_with_abort(&devices[..], &|| -> bool {
-            // We only supply a function in case it is high priority, hence always passing in
-            // `true`.
-            PriorityLock::should_break(true)
-        })
+        CpuGpuMultiexpKernel::create(&devices)
     } else {
-        CpuGpuMultiexpKernel::create(&devices[..])
+        // Low priority kernels may be aborted if a high priority kernel wants to run/is running.
+        CpuGpuMultiexpKernel::create_with_abort(&devices, &PriorityLock::is_taken)
     };
     match kernel {
         Ok(k) => {
             info!("GPU Multiexp kernel instantiated!");
-            Some((k, lock))
+            Some(k)
         }
         Err(e) => {
             warn!("Cannot instantiate GPU Multiexp kernel! Error: {}", e);
@@ -188,25 +153,31 @@ where
     }
 }
 
+/// Wrap the kernel so that only a single one runs on the GPU at a time.
 macro_rules! locked_kernel {
-    ($class:ident, $kern:ident, $func:ident, $name:expr) => {
-        #[allow(clippy::upper_case_acronyms)]
-        pub struct $class<'a, E>
-        where
-            E: pairing::Engine + ec_gpu::GpuEngine,
+    ($kernel:ty, $func:ident, $name:expr, pub struct $class:ident<$lifetime:lifetime, $generic:ident>
+        where $(
+            $bound:ty: $boundvalue:tt $(+ $morebounds:tt )*,
+        )+
+    ) => {
+        pub struct $class<$lifetime, $generic>
+        where $(
+            $bound : $boundvalue $(+ $morebounds)*,
+        )+
         {
             priority: bool,
             // Keep the GPU lock alongside the kernel, so that the lock is automatically dropped
             // if the kernel is dropped.
-            kernel_and_lock: Option<($kern<'a, E>, GPULock<'a>)>,
+            kernel_and_lock: Option<($kernel, GPULock)>,
         }
 
-        impl<'a, E> $class<'a, E>
-        where
-            E: pairing::Engine + ec_gpu::GpuEngine,
+        impl<'a, $generic> $class<$lifetime, $generic>
+        where $(
+            $bound: $boundvalue $(+ $morebounds)*,
+        )+
         {
-            pub fn new(priority: bool) -> $class<'a, E> {
-                $class::<E> {
+            pub fn new(priority: bool) -> Self {
+                Self {
                     priority,
                     kernel_and_lock: None,
                 }
@@ -219,8 +190,8 @@ macro_rules! locked_kernel {
                 if self.kernel_and_lock.is_none() {
                     PriorityLock::wait(self.priority);
                     info!("GPU is available for {}!", $name);
-                    if let Some((kernel, lock)) = $func::<E>(self.priority) {
-                        self.kernel_and_lock = Some((kernel, lock));
+                    if let Some(kernel) = $func(self.priority) {
+                        self.kernel_and_lock = Some((kernel, GPULock::lock()));
                     }
                 }
             }
@@ -238,9 +209,13 @@ macro_rules! locked_kernel {
                 }
             }
 
-            pub fn with<F, R>(&mut self, mut f: F) -> GpuResult<R>
+            /// Execute a function with the kernel.
+            ///
+            /// This function makes sure that only one things is run on the GPU at a time. It will
+            /// block until the GPU is available.
+            pub fn with<Fun, R>(&mut self, mut f: Fun) -> GpuResult<R>
             where
-                F: FnMut(&mut $kern<E>) -> GpuResult<R>,
+                Fun: FnMut(&mut $kernel) -> GpuResult<R>,
             {
                 if std::env::var("BELLMAN_NO_GPU").is_ok() {
                     return Err(GpuError::GpuDisabled);
@@ -253,7 +228,7 @@ macro_rules! locked_kernel {
                         match f(k) {
                             // Re-trying to run on the GPU is the core of this loop, all other
                             // cases abort the loop.
-                            Err(GpuError::GpuTaken) => {
+                            Err(GpuError::EcGpu(EcError::Aborted)) => {
                                 self.free();
                             }
                             Err(e) => {
@@ -271,10 +246,17 @@ macro_rules! locked_kernel {
     };
 }
 
-locked_kernel!(LockedFFTKernel, FftKernel, create_fft_kernel, "FFT");
 locked_kernel!(
-    LockedMultiexpKernel,
-    CpuGpuMultiexpKernel,
+    FftKernel<'a, F>,
+    create_fft_kernel,
+    "FFT",
+    pub struct LockedFftKernel<'a, F> where F: Field + GpuName,
+);
+locked_kernel!(
+    CpuGpuMultiexpKernel<'a, G>,
     create_multiexp_kernel,
-    "Multiexp"
+    "Multiexp",
+    pub struct LockedMultiexpKernel<'a, G>
+    where
+        G: PrimeCurveAffine + GpuName,
 );

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -139,11 +139,7 @@ where
     F: Field + GpuName,
 {
     let lock = GPULock::lock();
-    let mut devices = Vec::new();
-
-    for l in &lock.0 {
-        devices.push(l.1);
-    }
+    let devices = lock.0.iter().map(|(_, device, _)| *device).collect::<Vec<&Device>>();
 
     let programs = devices
         .iter()
@@ -174,11 +170,7 @@ where
     G: PrimeCurveAffine + GpuName,
 {
     let lock = GPULock::lock();
-    let mut devices = Vec::new();
-
-    for l in &lock.0 {
-        devices.push(l.1);
-    }
+    let devices = lock.0.iter().map(|(_, device, _)| *device).collect::<Vec<&Device>>();
 
     let kernel = if priority {
         CpuGpuMultiexpKernel::create(&devices)


### PR DESCRIPTION
original implementation lock bellman.gpu.lock to lock all GPUs in default. And in my test with cuda
single 3080 for C2: 15m52s
dual 3080 for C2: 12m36s
so i think it's better to let user to choice if they need to use all GPUs for one C2 task.
a environment named BELLPERSON_GPUS_PER_LOCK is introduced to let user to set.
if BELLPERSON_GPUS_PER_LOCK is not set, then we use all GPUs for one C2, just like current implementation;
if BELLPERSON_GPUS_PER_LOCK == 0, just like above;
if BELLPERSON_GPUS_PER_LOCK > 0, use BELLPERSON_GPUS_PER_LOCK GPUs (up to devices.len()) for one C2 task.

https://github.com/filecoin-project/bellperson/pull/298: circleci not work properly, so i re-create this one.