### PR TITLE
feat: make sha256_compression_function public

### DIFF
--- a/src/gadgets/sha256.rs
+++ b/src/gadgets/sha256.rs
@@ -80,7 +80,7 @@ fn get_sha256_iv() -> Vec<UInt32> {
     IV.iter().map(|&v| UInt32::constant(v)).collect()
 }
 
-fn sha256_compression_function<Scalar, CS>(
+pub fn sha256_compression_function<Scalar, CS>(
     cs: CS,
     input: &[Boolean],
     current_hash_value: &[UInt32],


### PR DESCRIPTION
The `sha256_compression_function()` function is now public, which was requested at https://github.com/filecoin-project/bellperson/issues/301.

Closes #301.