### PR TITLE
fix: disable GPU if BELLMAN_NO_GPU=0

### DIFF
--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -310,8 +310,10 @@ macro_rules! locked_kernel {
             where
                 Fun: FnMut(&mut $kernel) -> GpuResult<R>,
             {
-                if std::env::var("BELLMAN_NO_GPU").is_ok() {
-                    return Err(GpuError::GpuDisabled);
+                if let Ok(bellman_no_gpu) = std::env::var("BELLMAN_NO_GPU") {
+                    if bellman_no_gpu != "0" {
+                        return Err(GpuError::GpuDisabled);
+                    }
                 }
 
                 loop {


### PR DESCRIPTION
Prior to this change, the GPU was disabled, when the `BELLMAN_NO_GPU` environment variable was set to any value, even when set to 0.

Fixes #249.