### PR TITLE
Add WitnessCS, SizedWitness, and related ConstraintSystem methods.

### DIFF
--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -157,22 +157,42 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
         );
     }
 
+    /// Determines if the current `ConstraintSystem` instance is a witness generator.
     /// ConstraintSystems that are witness generators need not assemble the actual constraints. Rather, they exist only
     /// to efficiently create a witness.
+    ///
+    /// # Returns
+    ///
+    /// * `false` - By default, a `ConstraintSystem` is not a witness generator.
     fn is_witness_generator(&self) -> bool {
         false
     }
 
+    /// Extend the inputs of the `ConstraintSystem`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a `ConstraintSystem` that is also a witness generator.
     fn extend_inputs(&mut self, _new_inputs: &[Scalar]) {
         assert!(!self.is_witness_generator());
         unimplemented!()
     }
 
+    /// Extend the auxiliary inputs of the `ConstraintSystem`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a `ConstraintSystem` that is also a witness generator.
     fn extend_aux(&mut self, _new_aux: &[Scalar]) {
         assert!(!self.is_witness_generator());
         unimplemented!()
     }
 
+    /// Allocate empty space for the auxiliary inputs and the main inputs of the `ConstraintSystem`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a `ConstraintSystem` that is not a witness generator.
     fn allocate_empty(
         &mut self,
         _aux_n: usize,
@@ -183,12 +203,22 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
         unimplemented!()
     }
 
+    /// Allocate empty space for the main inputs of the `ConstraintSystem`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a `ConstraintSystem` that is not a witness generator.
     fn allocate_empty_inputs(&mut self, _n: usize) -> &mut [Scalar] {
         // This method should only ever be called on witness generators.
         assert!(self.is_witness_generator());
         unimplemented!()
     }
 
+    /// Allocate empty space for the auxiliary inputs of the `ConstraintSystem`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a `ConstraintSystem` that is not a witness generator.
     fn allocate_empty_aux(&mut self, _n: usize) -> &mut [Scalar] {
         // This method should only ever be called on witness generators.
         assert!(self.is_witness_generator());

--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -156,6 +156,44 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
             "ConstraintSystem::extend must be implemented for types implementing ConstraintSystem"
         );
     }
+
+    /// ConstraintSystems that are witness generators need not assemble the actual constraints. Rather, they exist only
+    /// to efficiently create a witness.
+    fn is_witness_generator(&mut self) -> bool {
+        false
+    }
+
+    fn extend_inputs(&mut self, _new_inputs: &[Scalar]) {
+        assert!(!self.is_witness_generator());
+        unimplemented!()
+    }
+
+    fn extend_aux(&mut self, _new_aux: &[Scalar]) {
+        assert!(!self.is_witness_generator());
+        unimplemented!()
+    }
+
+    fn allocate_empty(
+        &mut self,
+        _aux_n: usize,
+        _inputs_n: usize,
+    ) -> (&mut [Scalar], &mut [Scalar]) {
+        // This method should only ever be called on witness generators.
+        assert!(self.is_witness_generator());
+        unimplemented!()
+    }
+
+    fn allocate_empty_inputs(&mut self, _n: usize) -> &mut [Scalar] {
+        // This method should only ever be called on witness generators.
+        assert!(self.is_witness_generator());
+        unimplemented!()
+    }
+
+    fn allocate_empty_aux(&mut self, _n: usize) -> &mut [Scalar] {
+        // This method should only ever be called on witness generators.
+        assert!(self.is_witness_generator());
+        unimplemented!()
+    }
 }
 
 /// This is a "namespaced" constraint system which borrows a constraint system (pushing
@@ -221,6 +259,22 @@ impl<'cs, Scalar: PrimeField, CS: ConstraintSystem<Scalar>> ConstraintSystem<Sca
 
     fn get_root(&mut self) -> &mut Self::Root {
         self.0.get_root()
+    }
+
+    fn is_witness_generator(&mut self) -> bool {
+        self.get_root().is_witness_generator()
+    }
+
+    fn extend_inputs(&mut self, new_inputs: &[Scalar]) {
+        self.get_root().extend_inputs(new_inputs)
+    }
+
+    fn extend_aux(&mut self, new_aux: &[Scalar]) {
+        self.get_root().extend_aux(new_aux)
+    }
+
+    fn allocate_empty(&mut self, aux_n: usize, inputs_n: usize) -> (&mut [Scalar], &mut [Scalar]) {
+        self.get_root().allocate_empty(aux_n, inputs_n)
     }
 }
 

--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -172,9 +172,9 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
     ///
     /// # Panics
     ///
-    /// Panics if called on a `ConstraintSystem` that is also a witness generator.
+    /// Panics if called on a `ConstraintSystem` that is not a witness generator.
     fn extend_inputs(&mut self, _new_inputs: &[Scalar]) {
-        assert!(!self.is_witness_generator());
+        assert!(self.is_witness_generator());
         unimplemented!()
     }
 
@@ -182,9 +182,9 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
     ///
     /// # Panics
     ///
-    /// Panics if called on a `ConstraintSystem` that is also a witness generator.
+    /// Panics if called on a `ConstraintSystem` that is not a witness generator.
     fn extend_aux(&mut self, _new_aux: &[Scalar]) {
-        assert!(!self.is_witness_generator());
+        assert!(self.is_witness_generator());
         unimplemented!()
     }
 

--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -159,7 +159,7 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
 
     /// ConstraintSystems that are witness generators need not assemble the actual constraints. Rather, they exist only
     /// to efficiently create a witness.
-    fn is_witness_generator(&mut self) -> bool {
+    fn is_witness_generator(&self) -> bool {
         false
     }
 
@@ -261,20 +261,20 @@ impl<'cs, Scalar: PrimeField, CS: ConstraintSystem<Scalar>> ConstraintSystem<Sca
         self.0.get_root()
     }
 
-    fn is_witness_generator(&mut self) -> bool {
-        self.get_root().is_witness_generator()
+    fn is_witness_generator(&self) -> bool {
+        self.0.is_witness_generator()
     }
 
     fn extend_inputs(&mut self, new_inputs: &[Scalar]) {
-        self.get_root().extend_inputs(new_inputs)
+        self.0.extend_inputs(new_inputs)
     }
 
     fn extend_aux(&mut self, new_aux: &[Scalar]) {
-        self.get_root().extend_aux(new_aux)
+        self.0.extend_aux(new_aux)
     }
 
     fn allocate_empty(&mut self, aux_n: usize, inputs_n: usize) -> (&mut [Scalar], &mut [Scalar]) {
-        self.get_root().allocate_empty(aux_n, inputs_n)
+        self.0.allocate_empty(aux_n, inputs_n)
     }
 }
 
@@ -338,5 +338,45 @@ impl<'cs, Scalar: PrimeField, CS: ConstraintSystem<Scalar>> ConstraintSystem<Sca
 
     fn get_root(&mut self) -> &mut Self::Root {
         (**self).get_root()
+    }
+
+    fn namespace<NR, N>(&mut self, name_fn: N) -> Namespace<'_, Scalar, Self::Root>
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        (**self).namespace(name_fn)
+    }
+
+    fn is_extensible() -> bool {
+        CS::is_extensible()
+    }
+
+    fn extend(&mut self, _other: Self) {
+        unimplemented!()
+    }
+
+    fn is_witness_generator(&self) -> bool {
+        (**self).is_witness_generator()
+    }
+
+    fn extend_inputs(&mut self, new_inputs: &[Scalar]) {
+        (**self).extend_inputs(new_inputs)
+    }
+
+    fn extend_aux(&mut self, new_aux: &[Scalar]) {
+        (**self).extend_aux(new_aux)
+    }
+
+    fn allocate_empty(&mut self, aux_n: usize, inputs_n: usize) -> (&mut [Scalar], &mut [Scalar]) {
+        (**self).allocate_empty(aux_n, inputs_n)
+    }
+
+    fn allocate_empty_inputs(&mut self, n: usize) -> &mut [Scalar] {
+        (**self).allocate_empty_inputs(n)
+    }
+
+    fn allocate_empty_aux(&mut self, n: usize) -> &mut [Scalar] {
+        (**self).allocate_empty_aux(n)
     }
 }

--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -224,6 +224,26 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
         assert!(self.is_witness_generator());
         unimplemented!()
     }
+
+    /// Returns the constraint system's inputs as a slice of `Scalar`s.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a `ConstraintSystem` that is not a witness generator.
+    fn inputs_slice(&self) -> &[Scalar] {
+        assert!(self.is_witness_generator());
+        unimplemented!()
+    }
+
+    /// Returns the constraint system's aux witness as a slice of `Scalar`s.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a `ConstraintSystem` that is not a witness generator.
+    fn aux_slice(&self) -> &[Scalar] {
+        assert!(self.is_witness_generator());
+        unimplemented!()
+    }
 }
 
 /// This is a "namespaced" constraint system which borrows a constraint system (pushing
@@ -305,6 +325,13 @@ impl<'cs, Scalar: PrimeField, CS: ConstraintSystem<Scalar>> ConstraintSystem<Sca
 
     fn allocate_empty(&mut self, aux_n: usize, inputs_n: usize) -> (&mut [Scalar], &mut [Scalar]) {
         self.0.allocate_empty(aux_n, inputs_n)
+    }
+
+    fn inputs_slice(&self) -> &[Scalar] {
+        self.0.inputs_slice()
+    }
+    fn aux_slice(&self) -> &[Scalar] {
+        self.0.aux_slice()
     }
 }
 
@@ -408,5 +435,13 @@ impl<'cs, Scalar: PrimeField, CS: ConstraintSystem<Scalar>> ConstraintSystem<Sca
 
     fn allocate_empty_aux(&mut self, n: usize) -> &mut [Scalar] {
         (**self).allocate_empty_aux(n)
+    }
+
+    fn inputs_slice(&self) -> &[Scalar] {
+        (**self).inputs_slice()
+    }
+
+    fn aux_slice(&self) -> &[Scalar] {
+        (**self).aux_slice()
     }
 }

--- a/src/util_cs/mod.rs
+++ b/src/util_cs/mod.rs
@@ -4,6 +4,7 @@ use ff::PrimeField;
 pub mod bench_cs;
 pub mod metric_cs;
 pub mod test_cs;
+pub mod witness_cs;
 
 pub type Constraint<Scalar> = (
     LinearCombination<Scalar>,

--- a/src/util_cs/test_cs.rs
+++ b/src/util_cs/test_cs.rs
@@ -176,6 +176,17 @@ impl<Scalar: PrimeField> TestConstraintSystem<Scalar> {
         Default::default()
     }
 
+    pub fn scalar_inputs(&self) -> Vec<Scalar> {
+        self.inputs
+            .iter()
+            .map(|(scalar, _string)| *scalar)
+            .collect()
+    }
+
+    pub fn scalar_aux(&self) -> Vec<Scalar> {
+        self.aux.iter().map(|(scalar, _string)| *scalar).collect()
+    }
+
     pub fn pretty_print_list(&self) -> Vec<String> {
         let mut result = Vec::new();
 
@@ -340,6 +351,7 @@ impl<Scalar: PrimeField> Comparable<Scalar> for TestConstraintSystem<Scalar> {
             .map(|(_scalar, string)| string.to_string())
             .collect()
     }
+
     fn constraints(&self) -> &[crate::util_cs::Constraint<Scalar>] {
         &self.constraints
     }

--- a/src/util_cs/witness_cs.rs
+++ b/src/util_cs/witness_cs.rs
@@ -1,0 +1,193 @@
+//! Support for efficiently generating R1CS witness using bellperson.
+
+use ff::PrimeField;
+
+use crate::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+
+pub trait SizedWitness<Scalar: PrimeField> {
+    fn num_constraints(&self) -> usize;
+    fn num_inputs(&self) -> usize;
+    fn num_aux(&self) -> usize;
+
+    fn generate_witness_into(&mut self, aux: &mut [Scalar], inputs: &mut [Scalar]) -> Scalar;
+    fn generate_witness(&mut self) -> (Vec<Scalar>, Vec<Scalar>, Scalar) {
+        let aux_count = self.num_aux();
+        let inputs_count = self.num_inputs();
+
+        let mut aux = Vec::with_capacity(aux_count);
+        let mut inputs = Vec::with_capacity(inputs_count);
+
+        aux.resize(aux_count, Scalar::ZERO);
+        inputs.resize(inputs_count, Scalar::ZERO);
+
+        let result = self.generate_witness_into(&mut aux, &mut inputs);
+
+        (aux, inputs, result)
+    }
+
+    fn generate_witness_into_cs<CS: ConstraintSystem<Scalar>>(&mut self, cs: &mut CS) -> Scalar {
+        assert!(cs.is_witness_generator());
+
+        let aux_count = self.num_aux();
+        let inputs_count = self.num_inputs();
+
+        let (aux, inputs) = cs.allocate_empty(aux_count, inputs_count);
+
+        assert_eq!(aux.len(), aux_count);
+        assert_eq!(inputs.len(), inputs_count);
+
+        self.generate_witness_into(aux, inputs)
+    }
+}
+
+/// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
+pub struct WitnessCS<Scalar>
+where
+    Scalar: PrimeField,
+{
+    // Assignments of variables
+    pub(crate) input_assignment: Vec<Scalar>,
+    pub(crate) aux_assignment: Vec<Scalar>,
+}
+
+use std::fmt;
+
+impl<Scalar> fmt::Debug for WitnessCS<Scalar>
+where
+    Scalar: PrimeField,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("WitnessCS")
+            .field("input_assignment", &self.input_assignment)
+            .field("aux_assignment", &self.aux_assignment)
+            .finish()
+    }
+}
+
+impl<Scalar> PartialEq for WitnessCS<Scalar>
+where
+    Scalar: PrimeField,
+{
+    fn eq(&self, other: &WitnessCS<Scalar>) -> bool {
+        self.input_assignment == other.input_assignment
+            && self.aux_assignment == other.aux_assignment
+    }
+}
+
+impl<Scalar> ConstraintSystem<Scalar> for WitnessCS<Scalar>
+where
+    Scalar: PrimeField,
+{
+    type Root = Self;
+
+    fn new() -> Self {
+        let input_assignment = vec![Scalar::ONE];
+
+        Self {
+            input_assignment,
+            aux_assignment: vec![],
+        }
+    }
+
+    fn alloc<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<Scalar, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        self.aux_assignment.push(f()?);
+
+        Ok(Variable(Index::Aux(self.aux_assignment.len() - 1)))
+    }
+
+    fn alloc_input<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
+    where
+        F: FnOnce() -> Result<Scalar, SynthesisError>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        self.input_assignment.push(f()?);
+
+        Ok(Variable(Index::Input(self.input_assignment.len() - 1)))
+    }
+
+    fn enforce<A, AR, LA, LB, LC>(&mut self, _: A, _a: LA, _b: LB, _c: LC)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+        LA: FnOnce(LinearCombination<Scalar>) -> LinearCombination<Scalar>,
+        LB: FnOnce(LinearCombination<Scalar>) -> LinearCombination<Scalar>,
+        LC: FnOnce(LinearCombination<Scalar>) -> LinearCombination<Scalar>,
+    {
+        // Do nothing: we don't care about linear-combination evaluations in this context.
+    }
+
+    fn push_namespace<NR, N>(&mut self, _: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        // Do nothing; we don't care about namespaces in this context.
+    }
+
+    fn pop_namespace(&mut self) {
+        // Do nothing; we don't care about namespaces in this context.
+    }
+
+    fn get_root(&mut self) -> &mut Self::Root {
+        self
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Extensible
+    fn is_extensible() -> bool {
+        true
+    }
+
+    fn extend(&mut self, other: Self) {
+        self.input_assignment
+            // Skip first input, which must have been a temporarily allocated one variable.
+            .extend(&other.input_assignment[1..]);
+        self.aux_assignment.extend(other.aux_assignment);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Witness generator
+    fn is_witness_generator(&mut self) -> bool {
+        true
+    }
+
+    fn extend_inputs(&mut self, new_inputs: &[Scalar]) {
+        self.input_assignment.extend(new_inputs);
+    }
+
+    fn extend_aux(&mut self, new_aux: &[Scalar]) {
+        self.aux_assignment.extend(new_aux);
+    }
+
+    fn allocate_empty(&mut self, aux_n: usize, inputs_n: usize) -> (&mut [Scalar], &mut [Scalar]) {
+        let allocated_aux = {
+            let i = self.aux_assignment.len();
+            self.aux_assignment.resize(aux_n + i, Scalar::ZERO);
+            &mut self.aux_assignment[i..]
+        };
+
+        let allocated_inputs = {
+            let i = self.input_assignment.len();
+            self.input_assignment.resize(inputs_n + i, Scalar::ZERO);
+            &mut self.input_assignment[i..]
+        };
+
+        (allocated_aux, allocated_inputs)
+    }
+}
+
+impl<Scalar: PrimeField> WitnessCS<Scalar> {
+    pub fn scalar_inputs(&self) -> Vec<Scalar> {
+        self.input_assignment.clone()
+    }
+
+    pub fn scalar_aux(&self) -> Vec<Scalar> {
+        self.aux_assignment.clone()
+    }
+}

--- a/src/util_cs/witness_cs.rs
+++ b/src/util_cs/witness_cs.rs
@@ -130,7 +130,7 @@ where
 
     ////////////////////////////////////////////////////////////////////////////////
     // Witness generator
-    fn is_witness_generator(&mut self) -> bool {
+    fn is_witness_generator(&self) -> bool {
         true
     }
 

--- a/src/util_cs/witness_cs.rs
+++ b/src/util_cs/witness_cs.rs
@@ -40,7 +40,7 @@ pub trait SizedWitness<Scalar: PrimeField> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
 pub struct WitnessCS<Scalar>
 where

--- a/src/util_cs/witness_cs.rs
+++ b/src/util_cs/witness_cs.rs
@@ -40,6 +40,7 @@ pub trait SizedWitness<Scalar: PrimeField> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
 pub struct WitnessCS<Scalar>
 where
@@ -48,30 +49,6 @@ where
     // Assignments of variables
     pub(crate) input_assignment: Vec<Scalar>,
     pub(crate) aux_assignment: Vec<Scalar>,
-}
-
-use std::fmt;
-
-impl<Scalar> fmt::Debug for WitnessCS<Scalar>
-where
-    Scalar: PrimeField,
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("WitnessCS")
-            .field("input_assignment", &self.input_assignment)
-            .field("aux_assignment", &self.aux_assignment)
-            .finish()
-    }
-}
-
-impl<Scalar> PartialEq for WitnessCS<Scalar>
-where
-    Scalar: PrimeField,
-{
-    fn eq(&self, other: &WitnessCS<Scalar>) -> bool {
-        self.input_assignment == other.input_assignment
-            && self.aux_assignment == other.aux_assignment
-    }
 }
 
 impl<Scalar> ConstraintSystem<Scalar> for WitnessCS<Scalar>

--- a/src/util_cs/witness_cs.rs
+++ b/src/util_cs/witness_cs.rs
@@ -157,6 +157,14 @@ where
 
         (allocated_aux, allocated_inputs)
     }
+
+    fn inputs_slice(&self) -> &[Scalar] {
+        &self.input_assignment
+    }
+
+    fn aux_slice(&self) -> &[Scalar] {
+        &self.aux_assignment
+    }
 }
 
 impl<Scalar: PrimeField> WitnessCS<Scalar> {


### PR DESCRIPTION
This PR adds some new ConstraintSystem methods. These methods are intended to only be implemented by or called on ConstraintSystems that are also designated as witness generators. Such ConstraintSystems will signal this by implementing and returning true from `is_witness_generator()`. 

A minimal `WitnessCS` suitable for this purpose is also provided, as is a `SizedWitness` trait which should be implemented by objects (for example, implementers of `Circuit`) that choose to offer efficient witness-generation.

In this context, 'efficient witness generation' likely bypasses the usual, flexible mechanism used to specify `bellperson` circuits. Although convenient, this mechanism conflates synthesis and witness generation in ways that can add significant overhead.

Initial synthesis benchmarks in Neptune, although imperfect, showed 15x speedup when using this method, and this PR's immediate purpose is to support that use case.