### PR TITLE
fix: Upgrade ec-gpu-gen 0.7.0, make ConstraintSystem::extend by-ref

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ sha2 = "0.10.6"
 pairing = "0.23"
 blstrs = { version = "0.7.0", features = ["__private_bench"] }
 ec-gpu = { version = "0.2.0" }
-ec-gpu-gen = { version = "0.6.0" }
+ec-gpu-gen = { version = "0.7.0" }
 
 
 fs2 = { version = "0.4.3", optional = true }
@@ -90,5 +90,5 @@ members = [
 
 [build-dependencies]
 blstrs = { version = "0.7.0", features = ["__private_bench"] }
-ec-gpu-gen = { version = "0.6.0" }
+ec-gpu-gen = { version = "0.7.0" }
 rustversion = "1.0.6"

--- a/src/constraint_system.rs
+++ b/src/constraint_system.rs
@@ -151,7 +151,7 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
     /// entirely independent sub-circuits. Each can be synthesized in its own thread, then the
     /// original `ConstraintSystem` can be extended with each, in the same order they would have
     /// been synthesized sequentially.
-    fn extend(&mut self, _other: Self) {
+    fn extend(&mut self, _other: &Self) {
         unimplemented!(
             "ConstraintSystem::extend must be implemented for types implementing ConstraintSystem"
         );
@@ -409,8 +409,8 @@ impl<'cs, Scalar: PrimeField, CS: ConstraintSystem<Scalar>> ConstraintSystem<Sca
         CS::is_extensible()
     }
 
-    fn extend(&mut self, _other: Self) {
-        unimplemented!()
+    fn extend(&mut self, other: &Self) {
+        (**self).extend(other)
     }
 
     fn is_witness_generator(&self) -> bool {

--- a/src/groth16/prover.rs
+++ b/src/groth16/prover.rs
@@ -202,19 +202,19 @@ impl<Scalar: PrimeField> ConstraintSystem<Scalar> for ProvingAssignment<Scalar> 
         true
     }
 
-    fn extend(&mut self, other: Self) {
-        self.a_aux_density.extend(other.a_aux_density, false);
-        self.b_input_density.extend(other.b_input_density, true);
-        self.b_aux_density.extend(other.b_aux_density, false);
+    fn extend(&mut self, other: &Self) {
+        self.a_aux_density.extend(&other.a_aux_density, false);
+        self.b_input_density.extend(&other.b_input_density, true);
+        self.b_aux_density.extend(&other.b_aux_density, false);
 
-        self.a.extend(other.a);
-        self.b.extend(other.b);
-        self.c.extend(other.c);
+        self.a.extend(&other.a);
+        self.b.extend(&other.b);
+        self.c.extend(&other.c);
 
         self.input_assignment
             // Skip first input, which must have been a temporarily allocated one variable.
             .extend(&other.input_assignment[1..]);
-        self.aux_assignment.extend(other.aux_assignment);
+        self.aux_assignment.extend(&other.aux_assignment);
     }
 }
 
@@ -778,7 +778,7 @@ mod tests {
                     .alloc_input(|| "one", || Ok(<Fr as Field>::ONE))
                     .unwrap();
 
-                for assignment in partial_assignments.into_iter() {
+                for assignment in partial_assignments.iter() {
                     combined.extend(assignment);
                 }
                 assert_eq!(combined, full_assignment);

--- a/src/util_cs/witness_cs.rs
+++ b/src/util_cs/witness_cs.rs
@@ -121,11 +121,11 @@ where
         true
     }
 
-    fn extend(&mut self, other: Self) {
+    fn extend(&mut self, other: &Self) {
         self.input_assignment
             // Skip first input, which must have been a temporarily allocated one variable.
             .extend(&other.input_assignment[1..]);
-        self.aux_assignment.extend(other.aux_assignment);
+        self.aux_assignment.extend(&other.aux_assignment);
     }
 
     ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
See https://github.com/filecoin-project/bellperson/pull/309 for context:
- the signature of ConstraintSystem::extend prevents the correctness of an `impl<[...]CS: ConstraintSystem<Scalar>> ConstraintSystem<S> for &'cs mut CS`
- the upgrade to ec-gpu-gen 0.7.0 allows a change in signature of ConstraintSystem::extend, and re-establishing correct behavior for this convenience impl.
- this change is not backwards-compatible, as the former implementation had observable incorrect behavior (in particular deferral to default trait fields) that are not reproduced here.

This should re-target main once #309 is merged, ~~or can be merged therein.~~