### PR TITLE
Revert "Switch to self hosted CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install required packages
         run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
+      - name: Install cargo clippy
+        run: rustup component add clippy
       - name: Run cargo clippy
         run: cargo clippy --all-targets --workspace -- -D warnings
 
@@ -31,6 +33,8 @@ jobs:
     name: Checking fmt
     steps:
       - uses: actions/checkout@v4
+      - name: Install cargo fmt
+        run: rustup component add rustfmt
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-#on: [pull_request, push]
-on: [push]
+on: [pull_request, push]
 
 # Cancel a job if there's a new on on the same branch started.
 # Based on https://stackoverflow.com/questions/58895283/stop-already-running-workflow-job-in-github-actions/67223051#67223051
@@ -18,18 +17,17 @@ env:
 
 jobs:
   check_clippy:
-#    runs-on: ubuntu-24.04
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
     name: Clippy
     steps:
       - uses: actions/checkout@v4
-#      - name: Install required packages
-#        run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
+      - name: Install required packages
+        run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
       - name: Run cargo clippy
         run: cargo clippy --all-targets --workspace -- -D warnings
 
   check_fmt:
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
     name: Checking fmt
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +35,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   test_cpu:
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
     name: Test with CPU
     strategy:
       matrix:
@@ -49,39 +47,40 @@ jobs:
       - name: Show results (only for ignored tests)
         run: test -f aggregation.csv && cat aggregation.csv || true
 
-  test_gpu:
-    runs-on: self-hosted
-    name: Test
-    env:
-      # Build the kernel only for the single architecture that is used on CI.
-      # This should reduce the overall compile-time significantly.
-      BELLMAN_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
-      # These are needed for SupraSeal only, but it shouldn't do any harm for
-      # the other cases.
-      CC: gcc-12
-      CXX: g++-12
-      NVCC_PREPEND_FLAGS: "-ccbin /usr/bin/g++-12"
-    strategy:
-      matrix:
-        include:
-          - name: "Test OpenCL only"
-            cargo-args: "--workspace --release --features opencl"
-            framework: ""
-          - name: "Test CUDA only"
-          - cargo-args: "--release --features cuda"
-            framework: ""
-          - name: "Test CUDA/OpenCL (CUDA at run-time)"
-            cargo-args: "--release --features cuda,opencl"
-            framework: cuda
-          - name: "Test CUDA/OpenCL (OpenCL at run-time)"
-            cargo-args: "--release --features cuda,opencl"
-            framework: cuda
-          - name: "Test SupraSeal"
-            cargo-args: "--release --features cuda-supraseal"
-            framework: ""
-    steps:
-      - uses: actions/checkout@v4
-#      - name: Install required packages
-#        run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
-      - name: Test ${{ matrix.framework }} with ${{ matrix.cargo-args }}
-        run: BELLMAN_GPU_FRAMEWORK=${{ matrix.framework }} cargo test ${{ matrix.cargo-args }}
+  # Enable these tests once there's a runner with a GPU.
+  #test_gpu:
+  #  runs-on: ubuntu-24.04
+  #  name: Test
+  #  env:
+  #    # Build the kernel only for the single architecture that is used on CI.
+  #    # This should reduce the overall compile-time significantly.
+  #    BELLMAN_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
+  #    # These are needed for SupraSeal only, but it shouldn't do any harm for
+  #    # the other cases.
+  #    CC: gcc-12
+  #    CXX: g++-12
+  #    NVCC_PREPEND_FLAGS: "-ccbin /usr/bin/g++-12"
+  #  strategy:
+  #    matrix:
+  #      include:
+  #        - name: "Test OpenCL only"
+  #          cargo-args: "--workspace --release --features opencl"
+  #          framework: ""
+  #        - name: "Test CUDA only"
+  #        - cargo-args: "--release --features cuda"
+  #          framework: ""
+  #        - name: "Test CUDA/OpenCL (CUDA at run-time)"
+  #          cargo-args: "--release --features cuda,opencl"
+  #          framework: cuda
+  #        - name: "Test CUDA/OpenCL (OpenCL at run-time)"
+  #          cargo-args: "--release --features cuda,opencl"
+  #          framework: cuda
+  #        - name: "Test SupraSeal"
+  #          cargo-args: "--release --features cuda-supraseal"
+  #          framework: ""
+  #  steps:
+  #    - uses: actions/checkout@v4
+  #    - name: Install required packages
+  #      run: sudo apt install --no-install-recommends --yes libhwloc-dev nvidia-cuda-toolkit ocl-icd-opencl-dev
+  #    - name: Test ${{ matrix.framework }} with ${{ matrix.cargo-args }}
+  #      run: BELLMAN_GPU_FRAMEWORK=${{ matrix.framework }} cargo test ${{ matrix.cargo-args }}


### PR DESCRIPTION
Reverts filecoin-project/bellperson#324

This is related to https://github.com/filecoin-project/github-mgmt/issues/132. This is a temporary revert. We need to first get back on hosted runners before getting on FilOz's self-hosted runners, because `self-hosted` tag is too permissive and would start matching any FilOz's runners as soon as I allow this repository to access them. 