### PR TITLE
Fix Typo in Commit Key Documentation

### DIFF
--- a/src/groth16/aggregate/commit.rs
+++ b/src/groth16/aggregate/commit.rs
@@ -36,7 +36,7 @@ use crate::groth16::aggregate::inner_product;
 use bellpepper_core::SynthesisError;
 use pairing::{Engine, MultiMillerLoop};
 
-/// Key is a generic commitment key that is instanciated with g and h as basis,
+/// Key is a generic commitment key that is instantiated with g and h as basis,
 /// and a and b as powers.
 #[derive(Clone, Debug)]
 pub struct Key<G: PrimeCurveAffine> {

--- a/src/groth16/aggregate/proof.rs
+++ b/src/groth16/aggregate/proof.rs
@@ -154,7 +154,7 @@ where
         }
         Ok(())
     }
-    /// Writes the agggregated proof into the provided buffer.
+    /// Writes the aggregated proof into the provided buffer.
     pub fn write(&self, mut out: impl Write) -> std::io::Result<()> {
         // com_ab
         self.com_ab.0.write_compressed(&mut out)?;


### PR DESCRIPTION


---


**Description:**  
This pull request corrects a minor typo in the documentation comment for the `Key` struct in `commit.rs`.  
- Changed "instanciated" to "instantiated" for improved clarity and professionalism.



---