### PR TITLE
fix: correct typos in GPU-related code

### DIFF
--- a/src/gpu/error.rs
+++ b/src/gpu/error.rs
@@ -18,7 +18,7 @@ pub type GpuResult<T> = std::result::Result<T, GpuError>;
 
 impl From<GpuError> for SynthesisError {
     fn from(e: GpuError) -> Self {
-        // inspired by the commenct on MalformedProofs
+        // inspired by the comment on MalformedProofs
         SynthesisError::MalformedProofs(format!("Encountered a GPU Error: {}", e))
     }
 }

--- a/src/gpu/locks.rs
+++ b/src/gpu/locks.rs
@@ -130,7 +130,7 @@ impl Drop for GPULock<'_> {
     }
 }
 
-/// `PrioriyLock` is like a flag. When acquired, it means a high-priority process
+/// `PriorityLock` is like a flag. When acquired, it means a high-priority process
 /// needs to acquire the GPU really soon. Acquiring the `PriorityLock` is like
 /// signaling all other processes to release their `GPULock`s.
 /// Only one process can have the `PriorityLock` at a time.


### PR DESCRIPTION
- Fixed typo in comment: `commenct` → `comment` in `error.rs`.  
- Fixed struct name typo in doc comment: `PrioriyLock` → `PriorityLock` in `locks.rs`. 